### PR TITLE
Add support for a configuration function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,8 +29,12 @@ const defaultProps = {
 };
 
 export default {
-  addWithChapters(storyName, storyContent = {}) {
+  addWithChapters(storyName, storyContentOrFn = {}) {
     return this.add(storyName, (context) => {
+      const storyContent = typeof storyContentOrFn === 'function'
+          ? storyContentOrFn()
+          : storyContentOrFn;
+
       (storyContent.chapters || []).forEach((chapter) => {
         (chapter.sections || []).forEach((section) => {
           Object.assign(section, {

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -54,6 +54,22 @@ describe('Chapters Addon', () => {
       };
       addon.addWithChapters.call(scope, 'Story title', content);
     });
+    it('can be passed a function as a configuration argument', () => {
+      const expected = {
+        subtitle: 'Story subtitle',
+        info: 'Story info',
+        chapters: [],
+      };
+      const content = () => expected;
+      const scope = {
+        add(name, callback) {
+          const story = callback({});
+          const actual = story.props;
+          expect(actual).to.include.all.keys(expected);
+        },
+      };
+      addon.addWithChapters.call(scope, 'Story title', content);
+    });
   });
 
   describe('default options', () => {


### PR DESCRIPTION
```
.addWithChapters('name', () => ({
   chapters: [
      sections: [],
   ],
))
```

My use case for doing this involves the @storybook/addon-knobs package.
I would like to be able to share the value of a single knob between multiple sections.

For example:
```
.addWithChapters('icons', () => {
    const size = knobs.text('size', '1.2em');
    return {
        chapters: [
           sections: svgIcons.map((Icon) => ({
                 sectionFn: () => <Icon style={{ width: size, height: 'auto' }} />
           )
       ]
    }
});

```