### PR TITLE
Add opportunity to use react components as a title or subtitle

### DIFF
--- a/src/components/Chapter.jsx
+++ b/src/components/Chapter.jsx
@@ -6,8 +6,8 @@ import theme from '../theme';
 
 const propTypes = {
   context: PropTypes.object,
-  title: PropTypes.string,
-  subtitle: PropTypes.string,
+  title: PropTypes.oneOfType(PropTypes.string, PropTypes.node),
+  subtitle: PropTypes.oneOfType(PropTypes.string, PropTypes.node),
   info: PropTypes.string,
   sections: PropTypes.arrayOf(PropTypes.object),
   addonInfo: PropTypes.object,

--- a/src/components/Chapter.jsx
+++ b/src/components/Chapter.jsx
@@ -6,8 +6,8 @@ import theme from '../theme';
 
 const propTypes = {
   context: PropTypes.object,
-  title: PropTypes.oneOfType(PropTypes.string, PropTypes.node),
-  subtitle: PropTypes.oneOfType(PropTypes.string, PropTypes.node),
+  title: PropTypes.oneOfType(PropTypes.string, PropTypes.object),
+  subtitle: PropTypes.oneOfType(PropTypes.string, PropTypes.object),
   info: PropTypes.string,
   sections: PropTypes.arrayOf(PropTypes.object),
   addonInfo: PropTypes.object,

--- a/src/components/Section.jsx
+++ b/src/components/Section.jsx
@@ -6,8 +6,8 @@ import renderInfoContent from '../utils/info-content';
 import theme from '../theme';
 
 const propTypes = {
-  title: PropTypes.oneOfType(PropTypes.string, PropTypes.node),
-  subtitle: PropTypes.oneOfType(PropTypes.string, PropTypes.node),
+  title: PropTypes.oneOfType(PropTypes.string, PropTypes.object),
+  subtitle: PropTypes.oneOfType(PropTypes.string, PropTypes.object),
   info: PropTypes.string,
   showSource: PropTypes.bool,
   showPropTables: PropTypes.bool,

--- a/src/components/Section.jsx
+++ b/src/components/Section.jsx
@@ -6,8 +6,8 @@ import renderInfoContent from '../utils/info-content';
 import theme from '../theme';
 
 const propTypes = {
-  title: PropTypes.string,
-  subtitle: PropTypes.string,
+  title: PropTypes.oneOfType(PropTypes.string, PropTypes.node),
+  subtitle: PropTypes.oneOfType(PropTypes.string, PropTypes.node),
   info: PropTypes.string,
   showSource: PropTypes.bool,
   showPropTables: PropTypes.bool,

--- a/src/components/Story.jsx
+++ b/src/components/Story.jsx
@@ -7,8 +7,8 @@ import theme from '../theme';
 
 const propTypes = {
   context: PropTypes.object,
-  title: PropTypes.string,
-  subtitle: PropTypes.string,
+  title: PropTypes.oneOfType(PropTypes.string, PropTypes.node),
+  subtitle: PropTypes.oneOfType(PropTypes.string, PropTypes.node),
   info: PropTypes.string,
   chapters: PropTypes.arrayOf(PropTypes.object),
   addonInfo: PropTypes.object,

--- a/src/components/Story.jsx
+++ b/src/components/Story.jsx
@@ -7,8 +7,8 @@ import theme from '../theme';
 
 const propTypes = {
   context: PropTypes.object,
-  title: PropTypes.oneOfType(PropTypes.string, PropTypes.node),
-  subtitle: PropTypes.oneOfType(PropTypes.string, PropTypes.node),
+  title: PropTypes.oneOfType(PropTypes.string, PropTypes.object),
+  subtitle: PropTypes.oneOfType(PropTypes.string, PropTypes.object),
   info: PropTypes.string,
   chapters: PropTypes.arrayOf(PropTypes.object),
   addonInfo: PropTypes.object,


### PR DESCRIPTION
Hey! We have a need to add anchor links (link with hash to the content) for the Sections and Chapters and right now it's possible to send react component as a `title`, but it started firing warnings about a mismatch of the prop types. Please help us to make titles and subtitles extendable for everyone 😄  thanks! 😄