### PR TITLE
fix vulnerabilities found by npm audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,10 +53,10 @@
     "@babel/plugin-proposal-class-properties": "^7.3.4",
     "@babel/polyfill": "^7.2.5",
     "@emotion/styled": "^10.0.7",
-    "@storybook/addon-info": "^5.0.0",
+    "@storybook/addon-info": "github:storybooks/storybook#d739347ee9f10e6679a0ccbf399a4dd72ba6cf96",
     "@storybook/components": "^5.0.0",
     "@storybook/react": "^5.0.0",
-    "marksy": "2.0.1",
+    "marksy": "^7.0.1",
     "react": "^16.8.4"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
`marksy` had a vulnerability which storybook fixed in https://github.com/storybooks/storybook/commit/d739347ee9f10e6679a0ccbf399a4dd72ba6cf96. 

their v5.1.0 should include it as well since it's in for v5.1.0-beta.0 but didn't want to risk adding more changes in this PR so commit `sha` was linked instead.

Test plan:

```
npm i
npm audit
# should not log vulnerabilities
```