### PR TITLE
Poached Node file from addon-info previous version before it was depr…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "react-storybook-addon-chapters",
-	"version": "3.1.5",
+	"version": "3.1.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@babel/cli": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.5.5.tgz",
-			"integrity": "sha512-UHI+7pHv/tk9g6WXQKYz+kmXTI77YtuY3vqC59KIqcoWEjsJJSG6rAxKaLsgj3LDyadsPrCB929gVOKM6Hui0w==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.6.0.tgz",
+			"integrity": "sha512-1CTDyGUjQqW3Mz4gfKZ04KGOckyyaNmKneAMlABPS+ZyuxWv3FrVEVz7Ag08kNIztVx8VaJ8YgvYLSNlMKAT5Q==",
 			"dev": true,
 			"requires": {
-				"chokidar": "^2.0.4",
+				"chokidar": "^2.1.8",
 				"commander": "^2.8.1",
 				"convert-source-map": "^1.1.0",
 				"fs-readdir-recursive": "^1.1.0",
@@ -22,6 +22,20 @@
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
 				"slash": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -39,17 +53,17 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
-			"integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
+			"integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
-				"@babel/helpers": "^7.5.5",
-				"@babel/parser": "^7.5.5",
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5",
+				"@babel/generator": "^7.6.0",
+				"@babel/helpers": "^7.6.0",
+				"@babel/parser": "^7.6.0",
+				"@babel/template": "^7.6.0",
+				"@babel/traverse": "^7.6.0",
+				"@babel/types": "^7.6.0",
 				"convert-source-map": "^1.1.0",
 				"debug": "^4.1.0",
 				"json5": "^2.1.0",
@@ -60,18 +74,18 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
 		},
 		"@babel/generator": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-			"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
+			"integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
 			"requires": {
-				"@babel/types": "^7.5.5",
+				"@babel/types": "^7.6.0",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.13",
 				"source-map": "^0.5.0",
@@ -115,9 +129,9 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.5.5.tgz",
-			"integrity": "sha512-ZsxkyYiRA7Bg+ZTRpPvB6AbOFKTFFK4LrvTet8lInm0V468MWCaSYJE+I7v2z2r8KNLtYiV+K5kTCnR7dvyZjg==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.6.0.tgz",
+			"integrity": "sha512-O1QWBko4fzGju6VoVvrZg0RROCVifcLxiApnGP3OWfWzvxRZFCoBD81K5ur5e3bVY2Vf/5rIJm8cqPKn8HUJng==",
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-member-expression-to-functions": "^7.5.5",
@@ -274,13 +288,13 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
-			"integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.0.tgz",
+			"integrity": "sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==",
 			"requires": {
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5"
+				"@babel/template": "^7.6.0",
+				"@babel/traverse": "^7.6.0",
+				"@babel/types": "^7.6.0"
 			}
 		},
 		"@babel/highlight": {
@@ -294,9 +308,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-			"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g=="
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
+			"integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.2.0",
@@ -318,11 +332,11 @@
 			}
 		},
 		"@babel/plugin-proposal-decorators": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.0.tgz",
-			"integrity": "sha512-d08TLmXeK/XbgCo7ZeZ+JaeZDtDai/2ctapTRsWWkkmy7G/cqz8DQN/HlWG7RR4YmfXxmExsbU3SuCjlM7AtUg==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.4.tgz",
+			"integrity": "sha512-z7MpQz3XC/iQJWXH9y+MaWcLPNSMY9RQSthrLzak8R8hCj0fuyNk+Dzi9kfNe/JxxlWQ2g7wkABbgWjW36MTcw==",
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.4.0",
+				"@babel/helper-create-class-features-plugin": "^7.4.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-decorators": "^7.2.0"
 			}
@@ -472,9 +486,9 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz",
-			"integrity": "sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.0.tgz",
+			"integrity": "sha512-tIt4E23+kw6TgL/edACZwP1OUKrjOTyMrFMLoT5IOFrfMRabCgekjqFd5o6PaAMildBu46oFkekIdMuGkkPEpA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"lodash": "^4.17.13"
@@ -504,9 +518,9 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
-			"integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
+			"integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -591,9 +605,9 @@
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
-			"integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
+			"integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
 			"requires": {
 				"@babel/helper-module-transforms": "^7.4.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -621,11 +635,11 @@
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
-			"integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.0.tgz",
+			"integrity": "sha512-jem7uytlmrRl3iCAuQyw8BpB4c4LWvSpvIeXKpMb+7j84lkx4m4mYr5ErAcmN5KM7B6BqrAvRGjBIbbzqCczew==",
 			"requires": {
-				"regexp-tree": "^0.1.6"
+				"regexp-tree": "^0.1.13"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
@@ -664,9 +678,9 @@
 			}
 		},
 		"@babel/plugin-transform-react-constant-elements": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.5.0.tgz",
-			"integrity": "sha512-c5Ba8cpybZFp1Izkf2sWGuNjOxoQ32tFgBvvYvwGhi4+9f6vGiSK9Gex4uVuO/Va6YJFu41aAh1MzMjUWkp0IQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.6.0.tgz",
+			"integrity": "sha512-np/nPuII8DHOZWB3u8u+NSeKlEz0eBrOlnVksIQog4C9NGVzXO+NLxMcXn4Eu4GMFzOw2W6Tyo6L3+Wv8z9Y5w==",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -728,7 +742,6 @@
 			"version": "7.5.5",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.5.tgz",
 			"integrity": "sha512-6Xmeidsun5rkwnGfMOp6/z9nSzWpHFNVr2Jx7kwoq4mVatQfQx5S56drBgEHF+XQbKOdIaOiMIINvp/kAwMN+w==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -737,10 +750,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
 		},
@@ -787,11 +799,11 @@
 			}
 		},
 		"@babel/plugin-transform-typescript": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.5.5.tgz",
-			"integrity": "sha512-pehKf4m640myZu5B2ZviLaiBlxMCjSZ1qTEO459AXKX5GnPueyulJeCqZFs1nz/Ya2dDzXQ1NxZ/kKNWyD4h6w==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.6.0.tgz",
+			"integrity": "sha512-yzw7EopOOr6saONZ3KA3lpizKnWRTe+rfBqg4AmQbSow7ik7fqmzrfIqt053osLwLE2AaTqGinLM2tl6+M/uog==",
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.5.5",
+				"@babel/helper-create-class-features-plugin": "^7.6.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-typescript": "^7.2.0"
 			}
@@ -807,18 +819,18 @@
 			}
 		},
 		"@babel/polyfill": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
-			"integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.6.0.tgz",
+			"integrity": "sha512-q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==",
 			"requires": {
 				"core-js": "^2.6.5",
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz",
-			"integrity": "sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.0.tgz",
+			"integrity": "sha512-1efzxFv/TcPsNXlRhMzRnkBFMeIqBBgzwmZwlFDw5Ubj0AGLeufxugirwZmkkX/ayi3owsSqoQ4fw8LkfK9SYg==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -836,10 +848,10 @@
 				"@babel/plugin-transform-arrow-functions": "^7.2.0",
 				"@babel/plugin-transform-async-to-generator": "^7.5.0",
 				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-				"@babel/plugin-transform-block-scoping": "^7.5.5",
+				"@babel/plugin-transform-block-scoping": "^7.6.0",
 				"@babel/plugin-transform-classes": "^7.5.5",
 				"@babel/plugin-transform-computed-properties": "^7.2.0",
-				"@babel/plugin-transform-destructuring": "^7.5.0",
+				"@babel/plugin-transform-destructuring": "^7.6.0",
 				"@babel/plugin-transform-dotall-regex": "^7.4.4",
 				"@babel/plugin-transform-duplicate-keys": "^7.5.0",
 				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
@@ -848,10 +860,10 @@
 				"@babel/plugin-transform-literals": "^7.2.0",
 				"@babel/plugin-transform-member-expression-literals": "^7.2.0",
 				"@babel/plugin-transform-modules-amd": "^7.5.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.5.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.6.0",
 				"@babel/plugin-transform-modules-systemjs": "^7.5.0",
 				"@babel/plugin-transform-modules-umd": "^7.2.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.6.0",
 				"@babel/plugin-transform-new-target": "^7.4.4",
 				"@babel/plugin-transform-object-super": "^7.5.5",
 				"@babel/plugin-transform-parameters": "^7.4.4",
@@ -864,7 +876,7 @@
 				"@babel/plugin-transform-template-literals": "^7.4.4",
 				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
 				"@babel/plugin-transform-unicode-regex": "^7.4.4",
-				"@babel/types": "^7.5.5",
+				"@babel/types": "^7.6.0",
 				"browserslist": "^4.6.0",
 				"core-js-compat": "^3.1.1",
 				"invariant": "^2.2.2",
@@ -873,9 +885,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
 		},
@@ -910,12 +922,11 @@
 			}
 		},
 		"@babel/register": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.5.5.tgz",
-			"integrity": "sha512-pdd5nNR+g2qDkXZlW1yRCWFlNrAn2PPdnZUB72zjX4l1Vv4fMRRLwyf+n/idFCLI1UgVGboUU8oVziwTBiyNKQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.6.0.tgz",
+			"integrity": "sha512-78BomdN8el+x/nkup9KwtjJXuptW5oXMFmP11WoM2VJBjxrKv4grC3qjpLL8RGGUYUGsm57xnjYFM2uom+jWUQ==",
 			"dev": true,
 			"requires": {
-				"core-js": "^3.0.0",
 				"find-cache-dir": "^2.0.0",
 				"lodash": "^4.17.13",
 				"mkdirp": "^0.5.1",
@@ -923,12 +934,6 @@
 				"source-map-support": "^0.5.9"
 			},
 			"dependencies": {
-				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==",
-					"dev": true
-				},
 				"find-cache-dir": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
@@ -943,69 +948,74 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
-			"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
+			"integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/template": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-			"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+			"integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.4.4",
-				"@babel/types": "^7.4.4"
+				"@babel/parser": "^7.6.0",
+				"@babel/types": "^7.6.0"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-			"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz",
+			"integrity": "sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==",
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
+				"@babel/generator": "^7.6.0",
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-split-export-declaration": "^7.4.4",
-				"@babel/parser": "^7.5.5",
-				"@babel/types": "^7.5.5",
+				"@babel/parser": "^7.6.0",
+				"@babel/types": "^7.6.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/types": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-			"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
+			"integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.13",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@base2/pretty-print-object": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz",
+			"integrity": "sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw=="
+		},
 		"@emotion/cache": {
-			"version": "10.0.14",
-			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.14.tgz",
-			"integrity": "sha512-HNGEwWnPlNyy/WPXBXzbjzkzeZFV657Z99/xq2xs5yinJHbMfi3ioCvBJ6Y8Zc8DQzO9F5jDmVXJB41Ytx3QMw==",
+			"version": "10.0.19",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.19.tgz",
+			"integrity": "sha512-BoiLlk4vEsGBg2dAqGSJu0vJl/PgVtCYLBFJaEO8RmQzPugXewQCXZJNXTDFaRlfCs0W+quesayav4fvaif5WQ==",
 			"requires": {
 				"@emotion/sheet": "0.9.3",
 				"@emotion/stylis": "0.8.4",
 				"@emotion/utils": "0.11.2",
-				"@emotion/weak-memoize": "0.2.3"
+				"@emotion/weak-memoize": "0.2.4"
 			}
 		},
 		"@emotion/core": {
-			"version": "10.0.14",
-			"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.14.tgz",
-			"integrity": "sha512-G9FbyxLm3lSnPfLDcag8fcOQBKui/ueXmWOhV+LuEQg9HrqExuWnWaO6gm6S5rNe+AMcqLXVljf8pYgAdFLNSg==",
+			"version": "10.0.17",
+			"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.17.tgz",
+			"integrity": "sha512-gykyjjr0sxzVuZBVTVK4dUmYsorc2qLhdYgSiOVK+m7WXgcYTKZevGWZ7TLAgTZvMelCTvhNq8xnf8FR1IdTbg==",
 			"requires": {
-				"@babel/runtime": "^7.4.3",
-				"@emotion/cache": "^10.0.14",
+				"@babel/runtime": "^7.5.5",
+				"@emotion/cache": "^10.0.17",
 				"@emotion/css": "^10.0.14",
-				"@emotion/serialize": "^0.11.8",
+				"@emotion/serialize": "^0.11.10",
 				"@emotion/sheet": "0.9.3",
 				"@emotion/utils": "0.11.2"
 			}
@@ -1021,30 +1031,30 @@
 			}
 		},
 		"@emotion/hash": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.2.tgz",
-			"integrity": "sha512-RMtr1i6E8MXaBWwhXL3yeOU8JXRnz8GNxHvaUfVvwxokvayUY0zoBeWbKw1S9XkufmGEEdQd228pSZXFkAln8Q=="
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.3.tgz",
+			"integrity": "sha512-14ZVlsB9akwvydAdaEnVnvqu6J2P6ySv39hYyl/aoB6w/V+bXX0tay8cF6paqbgZsN2n5Xh15uF4pE+GvE+itw=="
 		},
 		"@emotion/is-prop-valid": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.2.tgz",
-			"integrity": "sha512-ZQIMAA2kLUWiUeMZNJDTeCwYRx1l8SQL0kHktze4COT22occKpDML1GDUXP5/sxhOMrZO8vZw773ni4H5Snrsg==",
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.3.tgz",
+			"integrity": "sha512-We7VBiltAJ70KQA0dWkdPMXnYoizlxOXpvtjmu5/MBnExd+u0PGgV27WCYanmLAbCwAU30Le/xA0CQs/F/Otig==",
 			"requires": {
-				"@emotion/memoize": "0.7.2"
+				"@emotion/memoize": "0.7.3"
 			}
 		},
 		"@emotion/memoize": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.2.tgz",
-			"integrity": "sha512-hnHhwQzvPCW1QjBWFyBtsETdllOM92BfrKWbUTmh9aeOlcVOiXvlPsK4104xH8NsaKfg86PTFsWkueQeUfMA/w=="
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.3.tgz",
+			"integrity": "sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow=="
 		},
 		"@emotion/serialize": {
-			"version": "0.11.8",
-			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.8.tgz",
-			"integrity": "sha512-Qb6Us2Yk1ZW8SOYH6s5z7qzXXb2iHwVeqc6FjXtac0vvxC416ki0eTtHNw4Q5smoyxdyZh3519NKGrQvvvrZ/Q==",
+			"version": "0.11.11",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.11.tgz",
+			"integrity": "sha512-YG8wdCqoWtuoMxhHZCTA+egL0RSGdHEc+YCsmiSBPBEDNuVeMWtjEWtGrhUterSChxzwnWBXvzSxIFQI/3sHLw==",
 			"requires": {
-				"@emotion/hash": "0.7.2",
-				"@emotion/memoize": "0.7.2",
+				"@emotion/hash": "0.7.3",
+				"@emotion/memoize": "0.7.3",
 				"@emotion/unitless": "0.7.4",
 				"@emotion/utils": "0.11.2",
 				"csstype": "^2.5.7"
@@ -1056,22 +1066,22 @@
 			"integrity": "sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A=="
 		},
 		"@emotion/styled": {
-			"version": "10.0.14",
-			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.14.tgz",
-			"integrity": "sha512-Ae8d5N/FmjvZKXjqWcjfhZhjCdkvxZSqD95Q72BYDNQnsOKLHIA4vWlMolLXDNkw1dIxV3l2pp82Z87HXj6eYQ==",
+			"version": "10.0.17",
+			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.17.tgz",
+			"integrity": "sha512-zHMgWjHDMNjD+ux64POtDnjLAObniu3znxFBLSdV/RiEhSLjHIowfvSbbd/C33/3uwtI6Uzs2KXnRZtka/PpAQ==",
 			"requires": {
-				"@emotion/styled-base": "^10.0.14",
-				"babel-plugin-emotion": "^10.0.14"
+				"@emotion/styled-base": "^10.0.17",
+				"babel-plugin-emotion": "^10.0.17"
 			}
 		},
 		"@emotion/styled-base": {
-			"version": "10.0.14",
-			"resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.14.tgz",
-			"integrity": "sha512-1nC5iO/Rk0DY47M5wXCyWpbo/woiwXWfVbNKDM3QRi7CKq8CwC++PQ5HgiYflFrAt1vjzIVZqnzrIn3idUoQgg==",
+			"version": "10.0.19",
+			"resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.19.tgz",
+			"integrity": "sha512-Sz6GBHTbOZoeZQKvkE9gQPzaJ6/qtoQ/OPvyG2Z/6NILlYk60Es1cEcTgTkm26H8y7A0GSgp4UmXl+srvsnFPg==",
 			"requires": {
-				"@babel/runtime": "^7.4.3",
-				"@emotion/is-prop-valid": "0.8.2",
-				"@emotion/serialize": "^0.11.8",
+				"@babel/runtime": "^7.5.5",
+				"@emotion/is-prop-valid": "0.8.3",
+				"@emotion/serialize": "^0.11.11",
 				"@emotion/utils": "0.11.2"
 			}
 		},
@@ -1091,9 +1101,14 @@
 			"integrity": "sha512-UHX2XklLl3sIaP6oiMmlVzT0J+2ATTVpf0dHQVyPJHTkOITvXfaSqnRk6mdDhV9pR8T/tHc3cex78IKXssmzrA=="
 		},
 		"@emotion/weak-memoize": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.3.tgz",
-			"integrity": "sha512-zVgvPwGK7c1aVdUVc9Qv7SqepOGRDrqCw7KZPSZziWGxSlbII3gmvGLPzLX4d0n0BMbamBacUrN22zOMyFFEkQ=="
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz",
+			"integrity": "sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA=="
+		},
+		"@icons/material": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
+			"integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
 		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
@@ -1122,9 +1137,9 @@
 			}
 		},
 		"@sinonjs/commons": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
-			"integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+			"integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
 			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
@@ -1141,14 +1156,14 @@
 			}
 		},
 		"@sinonjs/samsam": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
-			"integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+			"integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/commons": "^1.0.2",
+				"@sinonjs/commons": "^1.3.0",
 				"array-from": "^2.1.1",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@sinonjs/text-encoding": {
@@ -1157,17 +1172,46 @@
 			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
 			"dev": true
 		},
-		"@storybook/addon-info": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/@storybook/addon-info/-/addon-info-5.1.9.tgz",
-			"integrity": "sha512-KWGhW8kv/VUj4OnWyOmZx/Kq7CzSLGMIXFI6UQY9f6j6QiyShSaOKXgbNIhynjiYHq0hEnfbgUvws2DC9dDFuw==",
+		"@storybook/addon-actions": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-5.2.1.tgz",
+			"integrity": "sha512-tu4LGeRGAq+sLlsRPE1PzGyYU9JyM3HMLXnOCh5dvRSS8wnoDw1zQ55LPOXH6aoJGdsrvktiw+uTVf4OyN7ryg==",
 			"requires": {
-				"@storybook/addons": "5.1.9",
-				"@storybook/client-logger": "5.1.9",
-				"@storybook/components": "5.1.9",
-				"@storybook/theming": "5.1.9",
+				"@storybook/addons": "5.2.1",
+				"@storybook/api": "5.2.1",
+				"@storybook/client-api": "5.2.1",
+				"@storybook/components": "5.2.1",
+				"@storybook/core-events": "5.2.1",
+				"@storybook/theming": "5.2.1",
+				"core-js": "^3.0.1",
+				"fast-deep-equal": "^2.0.1",
+				"global": "^4.3.2",
+				"polished": "^3.3.1",
+				"prop-types": "^15.7.2",
+				"react": "^16.8.3",
+				"react-inspector": "^3.0.2",
+				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
+				}
+			}
+		},
+		"@storybook/addon-info": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/addon-info/-/addon-info-5.2.1.tgz",
+			"integrity": "sha512-/BLUXZT5UCayKaeglRZvkMiRzDrypUoWvDzYFDSBgYXfa9b2LJFYVEcwc6cC8Xtl5F225qXBPNnSNRnz7hDAeg==",
+			"requires": {
+				"@storybook/addons": "5.2.1",
+				"@storybook/client-logger": "5.2.1",
+				"@storybook/components": "5.2.1",
+				"@storybook/theming": "5.2.1",
 				"core-js": "^3.0.1",
 				"global": "^4.3.2",
+				"jsx-to-string": "^1.4.0",
 				"marksy": "^7.0.0",
 				"nested-object-assign": "^1.0.3",
 				"prop-types": "^15.7.2",
@@ -1180,9 +1224,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				},
 				"marksy": {
 					"version": "7.0.1",
@@ -1196,36 +1240,68 @@
 				}
 			}
 		},
-		"@storybook/addons": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.1.9.tgz",
-			"integrity": "sha512-1bavbcS/NiE65DwyKj8c0DmWmz9VekOinB+has2Pqt2bOffZoZwVnbmepcz9hH3GUyvp5fQBYbxTEmTDvF2lLA==",
+		"@storybook/addon-knobs": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-5.2.1.tgz",
+			"integrity": "sha512-JCSqrGYyVVBNkudhvla7qc9m0/Mn1UMaMzIxH5kewEE1KWZcCkdXD5hDASN39pkn3mX1yyqveP8jiyIL9vVBLg==",
 			"requires": {
-				"@storybook/api": "5.1.9",
-				"@storybook/channels": "5.1.9",
-				"@storybook/client-logger": "5.1.9",
+				"@storybook/addons": "5.2.1",
+				"@storybook/api": "5.2.1",
+				"@storybook/client-api": "5.2.1",
+				"@storybook/components": "5.2.1",
+				"@storybook/core-events": "5.2.1",
+				"@storybook/theming": "5.2.1",
+				"copy-to-clipboard": "^3.0.8",
+				"core-js": "^3.0.1",
+				"escape-html": "^1.0.3",
+				"fast-deep-equal": "^2.0.1",
+				"global": "^4.3.2",
+				"lodash": "^4.17.11",
+				"prop-types": "^15.7.2",
+				"qs": "^6.6.0",
+				"react-color": "^2.17.0",
+				"react-lifecycles-compat": "^3.0.4",
+				"react-select": "^3.0.0"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
+				}
+			}
+		},
+		"@storybook/addons": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.1.tgz",
+			"integrity": "sha512-kdx97tTKsMf/lBlT40uLYsHMF1J71mn2j41RNaCXmWw/PrKCDmiNfinemN2wtbwRSvGqb3q/BAqjKLvUtWynGg==",
+			"requires": {
+				"@storybook/api": "5.2.1",
+				"@storybook/channels": "5.2.1",
+				"@storybook/client-logger": "5.2.1",
+				"@storybook/core-events": "5.2.1",
 				"core-js": "^3.0.1",
 				"global": "^4.3.2",
 				"util-deprecate": "^1.0.2"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				}
 			}
 		},
 		"@storybook/api": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.1.9.tgz",
-			"integrity": "sha512-d1HhpOkW+706/WJ9lP5nCqOrp/icvbm0o+6jFFOGJ35AW5O9D8vDBxzvgMEO45jjN4I+rtbcNHQCxshSbPvP9w==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.1.tgz",
+			"integrity": "sha512-EXN6sqkGHRuNq0W6BZXOlxe2I2dmN0yUdQLiUOpzH2I3mXnVHpad/0v76dRc9fZbC4LaYUSxR8lBTr0rqIb4mA==",
 			"requires": {
-				"@storybook/channels": "5.1.9",
-				"@storybook/client-logger": "5.1.9",
-				"@storybook/core-events": "5.1.9",
-				"@storybook/router": "5.1.9",
-				"@storybook/theming": "5.1.9",
+				"@storybook/channels": "5.2.1",
+				"@storybook/client-logger": "5.2.1",
+				"@storybook/core-events": "5.2.1",
+				"@storybook/router": "5.2.1",
+				"@storybook/theming": "5.2.1",
 				"core-js": "^3.0.1",
 				"fast-deep-equal": "^2.0.1",
 				"global": "^4.3.2",
@@ -1236,99 +1312,103 @@
 				"semver": "^6.0.0",
 				"shallow-equal": "^1.1.0",
 				"store2": "^2.7.1",
-				"telejson": "^2.2.1",
+				"telejson": "^2.2.2",
 				"util-deprecate": "^1.0.2"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				}
 			}
 		},
 		"@storybook/channel-postmessage": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.1.9.tgz",
-			"integrity": "sha512-H71PsnDKW81eflOS48Lv9yK4O8AcoqXL6ohsWvLdrHWIBsH4zpjOIhdWHtmAaT3hyfMy+l49DQ+uCHLECEt55g==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.2.1.tgz",
+			"integrity": "sha512-gmnn9qU1iLCpfF6bZuEM3QQOZsAviWeIpiezjrd/qkxatgr3qtbXd4EoZpcVuQw314etarWtNxVpcX6PXcASjQ==",
 			"requires": {
-				"@storybook/channels": "5.1.9",
-				"@storybook/client-logger": "5.1.9",
+				"@storybook/channels": "5.2.1",
+				"@storybook/client-logger": "5.2.1",
 				"core-js": "^3.0.1",
 				"global": "^4.3.2",
-				"telejson": "^2.2.1"
+				"telejson": "^2.2.2"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				}
 			}
 		},
 		"@storybook/channels": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.1.9.tgz",
-			"integrity": "sha512-R6i7859FsXgY9XFFErVe7gS37wGYpQEEWsO1LzUW7YptGuFTUa8yLgKkNkgfy7Zs61Xm+GiBq8PvS/CWxjotPw==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.1.tgz",
+			"integrity": "sha512-AsF/Hwx91SDOgiOGOBSWS8EJAgqVm939n2nkfdLSJQQmX5EdPRAc3EIE3f13tyQub2yNx0OR4UzQDWgjwfVsEQ==",
 			"requires": {
 				"core-js": "^3.0.1"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				}
 			}
 		},
 		"@storybook/client-api": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.1.9.tgz",
-			"integrity": "sha512-J5HDtOS7x5YRpF/CMiHdxywV5NIh1i/03Xh2RhG15lmPy87VStIGpLzhF71uCRPLEJinYelcjuXRNAJgRzUOlg==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.2.1.tgz",
+			"integrity": "sha512-VxexqxrbORCGqwx2j0/91Eu1A/vq+rSVIesWwzIowmoLfBwRwDdskO20Yn9U7iMSpux4RvHGF6y1Q1ZtnXm9aA==",
 			"requires": {
-				"@storybook/addons": "5.1.9",
-				"@storybook/client-logger": "5.1.9",
-				"@storybook/core-events": "5.1.9",
-				"@storybook/router": "5.1.9",
+				"@storybook/addons": "5.2.1",
+				"@storybook/channel-postmessage": "5.2.1",
+				"@storybook/channels": "5.2.1",
+				"@storybook/client-logger": "5.2.1",
+				"@storybook/core-events": "5.2.1",
+				"@storybook/router": "5.2.1",
 				"common-tags": "^1.8.0",
 				"core-js": "^3.0.1",
-				"eventemitter3": "^3.1.0",
+				"eventemitter3": "^4.0.0",
 				"global": "^4.3.2",
 				"is-plain-object": "^3.0.0",
 				"lodash": "^4.17.11",
 				"memoizerific": "^1.11.3",
-				"qs": "^6.6.0"
+				"qs": "^6.6.0",
+				"util-deprecate": "^1.0.2"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				}
 			}
 		},
 		"@storybook/client-logger": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.1.9.tgz",
-			"integrity": "sha512-1+Otcn0EFgWNviDPNCR5LtUViADlboz9fmpZc7UY7bgaY5FVNIUO01E4T43tO7fduiRZoEvdltwTuQRm260Vjw==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.1.tgz",
+			"integrity": "sha512-wzxSE9t3DaLCdd/gnGFnjevmYRZ92F3TEwhUP/QDXM9cZkNsRKHkjE61qjiO5aQPaZQG6Ea9ayWEQEMgZXDucg==",
 			"requires": {
 				"core-js": "^3.0.1"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				}
 			}
 		},
 		"@storybook/components": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.1.9.tgz",
-			"integrity": "sha512-F4xcRlifSAfqkuFWtCKRvQDahXyfWBWV2Wa+kYy4YGwEfm3kKtIHVlgdgARL22g9BdYpRFEOJ+42juOu5YvIeQ==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.2.1.tgz",
+			"integrity": "sha512-cik5J/mTm1b1TOI17qM+2Mikk3rjb3SbBD4WlNz3Zvn+Hw0ukgbx6kQwVBgujhMlDtsHreidyEgIg4TM13S0Tg==",
 			"requires": {
-				"@storybook/client-logger": "5.1.9",
-				"@storybook/theming": "5.1.9",
+				"@storybook/client-logger": "5.2.1",
+				"@storybook/theming": "5.2.1",
+				"@types/react-syntax-highlighter": "10.1.0",
 				"core-js": "^3.0.1",
 				"global": "^4.3.2",
 				"markdown-to-jsx": "^6.9.1",
@@ -1343,40 +1423,40 @@
 				"react-popper-tooltip": "^2.8.3",
 				"react-syntax-highlighter": "^8.0.1",
 				"react-textarea-autosize": "^7.1.0",
-				"recompose": "^0.30.0",
 				"simplebar-react": "^1.0.0-alpha.6"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				}
 			}
 		},
 		"@storybook/core": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/@storybook/core/-/core-5.1.9.tgz",
-			"integrity": "sha512-P3aavCnl3Cl3WMXVERjQqnqV1Z8tN0tyOTqqiGb1fMxITSE8uZNvp33Dl0K3jr1PBl9trW+2t7eHH4h0sguLlQ==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/core/-/core-5.2.1.tgz",
+			"integrity": "sha512-mGGvN3GWeLxZ9lYZ4IuD1IoJD+cn6XXm2Arzw+k6KEtJJDFrC5SjESTDGLVFienX5s2tgH4FjYb9Ps9sKfhHlg==",
 			"requires": {
 				"@babel/plugin-proposal-class-properties": "^7.3.3",
 				"@babel/plugin-proposal-object-rest-spread": "^7.3.2",
 				"@babel/plugin-syntax-dynamic-import": "^7.2.0",
 				"@babel/plugin-transform-react-constant-elements": "^7.2.0",
 				"@babel/preset-env": "^7.4.5",
-				"@storybook/addons": "5.1.9",
-				"@storybook/channel-postmessage": "5.1.9",
-				"@storybook/client-api": "5.1.9",
-				"@storybook/client-logger": "5.1.9",
-				"@storybook/core-events": "5.1.9",
-				"@storybook/node-logger": "5.1.9",
-				"@storybook/router": "5.1.9",
-				"@storybook/theming": "5.1.9",
-				"@storybook/ui": "5.1.9",
+				"@storybook/addons": "5.2.1",
+				"@storybook/channel-postmessage": "5.2.1",
+				"@storybook/client-api": "5.2.1",
+				"@storybook/client-logger": "5.2.1",
+				"@storybook/core-events": "5.2.1",
+				"@storybook/node-logger": "5.2.1",
+				"@storybook/router": "5.2.1",
+				"@storybook/theming": "5.2.1",
+				"@storybook/ui": "5.2.1",
 				"airbnb-js-shims": "^1 || ^2",
+				"ansi-to-html": "^0.6.11",
 				"autoprefixer": "^9.4.9",
 				"babel-plugin-add-react-displayname": "^0.0.5",
-				"babel-plugin-emotion": "^10.0.9",
+				"babel-plugin-emotion": "^10.0.14",
 				"babel-plugin-macros": "^2.4.5",
 				"babel-preset-minify": "^0.5.0 || 0.6.0-alpha.5",
 				"boxen": "^3.0.0",
@@ -1386,8 +1466,8 @@
 				"commander": "^2.19.0",
 				"common-tags": "^1.8.0",
 				"core-js": "^3.0.1",
-				"corejs-upgrade-webpack-plugin": "^2.0.0",
-				"css-loader": "^2.1.1",
+				"corejs-upgrade-webpack-plugin": "^2.2.0",
+				"css-loader": "^3.0.0",
 				"detect-port": "^1.3.0",
 				"dotenv-webpack": "^1.7.0",
 				"ejs": "^2.6.1",
@@ -1402,7 +1482,7 @@
 				"interpret": "^1.2.0",
 				"ip": "^1.1.5",
 				"json5": "^2.1.0",
-				"lazy-universal-dotenv": "^3.0.0",
+				"lazy-universal-dotenv": "^3.0.1",
 				"node-fetch": "^2.6.0",
 				"open": "^6.1.0",
 				"pnp-webpack-plugin": "1.4.3",
@@ -1420,7 +1500,8 @@
 				"shelljs": "^0.8.3",
 				"style-loader": "^0.23.1",
 				"terser-webpack-plugin": "^1.2.4",
-				"url-loader": "^1.1.2",
+				"unfetch": "^4.1.0",
+				"url-loader": "^2.0.1",
 				"util-deprecate": "^1.0.2",
 				"webpack": "^4.33.0",
 				"webpack-dev-middleware": "^3.7.0",
@@ -1428,9 +1509,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				},
 				"node-fetch": {
 					"version": "2.6.0",
@@ -1450,24 +1531,24 @@
 			}
 		},
 		"@storybook/core-events": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.1.9.tgz",
-			"integrity": "sha512-jHe2uyoLj9i6fntHtOj5azfGdLOb75LF0e1xXE8U2SX7Zp3uwbLAcfJ+dPStdc/q+f/wBiip3tH1dIjaNuUiMw==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.1.tgz",
+			"integrity": "sha512-AIYV/I+baQ0KxvEM7QAKqUedLn2os0XU9HTdtfZJTC3U9wjmR2ah2ScD6T0n7PBz3MderkvZG6dNjs9h8gRquQ==",
 			"requires": {
 				"core-js": "^3.0.1"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				}
 			}
 		},
 		"@storybook/node-logger": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-5.1.9.tgz",
-			"integrity": "sha512-rcSuI5n53hDMHW83gl5TR0Yn885/i2XY0AzX1DsbTeGOl3x5LhrCSZsZWetKGcx7zsO4n7o5mQszLuN1JlyE8A==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-5.2.1.tgz",
+			"integrity": "sha512-rz+snXZyKwTegKEf15w4uaFWIKpgaWzTw+Ar8mxa+mX7C2DP65TOc+JGYZ7lsXdred+0WP0DhnmhGu2cX8z3lA==",
 			"requires": {
 				"chalk": "^2.4.2",
 				"core-js": "^3.0.1",
@@ -1477,9 +1558,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				},
 				"regenerator-runtime": {
 					"version": "0.12.1",
@@ -1489,15 +1570,16 @@
 			}
 		},
 		"@storybook/react": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/@storybook/react/-/react-5.1.9.tgz",
-			"integrity": "sha512-Byykpsttf6p2jv3LvqFtntEYfbUZSNTts0TjcZHNsHoUGmT7/M1PyqTeB7JUcYUNwSgdACY8FbowCrwZwDJDWQ==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/react/-/react-5.2.1.tgz",
+			"integrity": "sha512-brUG8iK2+1Fk5VFZWpAoSokCx21MaPX1zSAVA+Z/Ia0I0sFfurhpQgAGlVePTy9r7dtEEEdniZVtJOH/tHqk4Q==",
 			"requires": {
 				"@babel/plugin-transform-react-constant-elements": "^7.2.0",
 				"@babel/preset-flow": "^7.0.0",
 				"@babel/preset-react": "^7.0.0",
-				"@storybook/core": "5.1.9",
-				"@storybook/node-logger": "5.1.9",
+				"@storybook/addons": "5.2.1",
+				"@storybook/core": "5.2.1",
+				"@storybook/node-logger": "5.2.1",
 				"@svgr/webpack": "^4.0.3",
 				"babel-plugin-add-react-displayname": "^0.0.5",
 				"babel-plugin-named-asset-import": "^0.3.1",
@@ -1516,9 +1598,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				},
 				"regenerator-runtime": {
 					"version": "0.12.1",
@@ -1528,36 +1610,38 @@
 			}
 		},
 		"@storybook/router": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.1.9.tgz",
-			"integrity": "sha512-eAmeerE/OTIwCV7WBnb1BPINVN1GTSMsUXLNWpqSISuyWJ+NZAJlObFkvXoc57QSQlv0cvXlm1FMkmRt8ku1Hw==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.1.tgz",
+			"integrity": "sha512-Mlk275cyPoKtnP4DwQ5D8gTfnaRPL6kDZOSn0wbTMa6pQOfYKgJsa7tjzeAtZuZ/j8hKI4gAfT/auMgH6g+94A==",
 			"requires": {
 				"@reach/router": "^1.2.1",
+				"@types/reach__router": "^1.2.3",
 				"core-js": "^3.0.1",
 				"global": "^4.3.2",
+				"lodash": "^4.17.11",
 				"memoizerific": "^1.11.3",
 				"qs": "^6.6.0"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				}
 			}
 		},
 		"@storybook/theming": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.1.9.tgz",
-			"integrity": "sha512-4jIFJwTWVf9tsv27noLoFHlKC2Jl9DHV3q+rxGPU8bTNbufCu4oby82SboO5GAKuS3eu1cxL1YY9pYad9WxfHg==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.1.tgz",
+			"integrity": "sha512-lbAfcyI7Tx8swduIPmlu/jdWzqTBN/v82IEQbZbPR4LS5OHRPmhXPNgFGrcH4kFAiD0GoezSsdum1x0ZZpsQUQ==",
 			"requires": {
-				"@emotion/core": "^10.0.9",
-				"@emotion/styled": "^10.0.7",
-				"@storybook/client-logger": "5.1.9",
+				"@emotion/core": "^10.0.14",
+				"@emotion/styled": "^10.0.14",
+				"@storybook/client-logger": "5.2.1",
 				"common-tags": "^1.8.0",
 				"core-js": "^3.0.1",
 				"deep-object-diff": "^1.1.0",
-				"emotion-theming": "^10.0.9",
+				"emotion-theming": "^10.0.14",
 				"global": "^4.3.2",
 				"memoizerific": "^1.11.3",
 				"polished": "^3.3.1",
@@ -1566,9 +1650,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				},
 				"resolve-from": {
 					"version": "5.0.0",
@@ -1578,22 +1662,24 @@
 			}
 		},
 		"@storybook/ui": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-5.1.9.tgz",
-			"integrity": "sha512-guzKv4VYM+06BzMXeO3QqlX0IwUHyeS6lwdPCL8Oy2V4Gi2IYHHiD6Hr1NgnBO18j9luxE38f4Ii7gEIzXMFbQ==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-5.2.1.tgz",
+			"integrity": "sha512-h6Yf1ro/nZcz4nQAU+eSVPxVmpqv7uT7RMb3Vz+VLTY59IEA/sWcoIgA4MIxwf14nVcWOqSmVBJzNKWwc+NGJw==",
 			"requires": {
-				"@storybook/addons": "5.1.9",
-				"@storybook/api": "5.1.9",
-				"@storybook/channels": "5.1.9",
-				"@storybook/client-logger": "5.1.9",
-				"@storybook/components": "5.1.9",
-				"@storybook/core-events": "5.1.9",
-				"@storybook/router": "5.1.9",
-				"@storybook/theming": "5.1.9",
+				"@storybook/addon-actions": "5.2.1",
+				"@storybook/addon-knobs": "5.2.1",
+				"@storybook/addons": "5.2.1",
+				"@storybook/api": "5.2.1",
+				"@storybook/channels": "5.2.1",
+				"@storybook/client-logger": "5.2.1",
+				"@storybook/components": "5.2.1",
+				"@storybook/core-events": "5.2.1",
+				"@storybook/router": "5.2.1",
+				"@storybook/theming": "5.2.1",
 				"copy-to-clipboard": "^3.0.8",
 				"core-js": "^3.0.1",
 				"core-js-pure": "^3.0.1",
-				"emotion-theming": "^10.0.10",
+				"emotion-theming": "^10.0.14",
 				"fast-deep-equal": "^2.0.1",
 				"fuse.js": "^3.4.4",
 				"global": "^4.3.2",
@@ -1605,23 +1691,22 @@
 				"qs": "^6.6.0",
 				"react": "^16.8.3",
 				"react-dom": "^16.8.3",
-				"react-draggable": "^3.1.1",
+				"react-draggable": "^3.3.2",
 				"react-helmet-async": "^1.0.2",
 				"react-hotkeys": "2.0.0-pre4",
-				"react-resize-detector": "^4.0.5",
-				"recompose": "^0.30.0",
+				"react-sizeme": "^2.6.7",
 				"regenerator-runtime": "^0.13.2",
 				"resolve-from": "^5.0.0",
 				"semver": "^6.0.0",
 				"store2": "^2.7.1",
-				"telejson": "^2.2.1",
+				"telejson": "^2.2.2",
 				"util-deprecate": "^1.0.2"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				},
 				"resolve-from": {
 					"version": "5.0.0",
@@ -1739,16 +1824,52 @@
 				"loader-utils": "^1.2.3"
 			}
 		},
+		"@types/history": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.3.tgz",
+			"integrity": "sha512-cS5owqtwzLN5kY+l+KgKdRJ/Cee8tlmQoGQuIE9tWnSmS3JMKzmxo2HIAk2wODMifGwO20d62xZQLYz+RLfXmw=="
+		},
 		"@types/node": {
-			"version": "12.6.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
-			"integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
+			"version": "12.7.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
+			"integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
 			"dev": true
+		},
+		"@types/prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-f8JzJNWVhKtc9dg/dyDNfliTKNOJSLa7Oht/ElZdF/UbMUmAH3rLmAk3ODNjw0mZajDEgatA03tRjB4+Dp/tzA=="
 		},
 		"@types/q": {
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
 			"integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
+		},
+		"@types/reach__router": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.2.4.tgz",
+			"integrity": "sha512-a+MFhebeSGi0LwHZ0UhH/ke77rWtNQnt8YmaHnquSaY3HmyEi+BPQi3GhPcUPnC9X5BLw/qORw3BPxGb1mCtEw==",
+			"requires": {
+				"@types/history": "*",
+				"@types/react": "*"
+			}
+		},
+		"@types/react": {
+			"version": "16.9.2",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.2.tgz",
+			"integrity": "sha512-jYP2LWwlh+FTqGd9v7ynUKZzjj98T8x7Yclz479QdRhHfuW9yQ+0jjnD31eXSXutmBpppj5PYNLYLRfnZJvcfg==",
+			"requires": {
+				"@types/prop-types": "*",
+				"csstype": "^2.2.0"
+			}
+		},
+		"@types/react-syntax-highlighter": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-10.1.0.tgz",
+			"integrity": "sha512-dF49hC4FZp1dIKyzacOrHvqMUe8U2IXyQCQXOcT1e6n64gLBp+xM6qGtPsThIT9XjiIHSg2W5Jc2V5IqekBfnA==",
+			"requires": {
+				"@types/react": "*"
+			}
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.8.5",
@@ -1919,9 +2040,9 @@
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
 		},
 		"abab": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
-			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.1.tgz",
+			"integrity": "sha512-1zSbbCuoIjafKZ3mblY5ikvAb0ODUbqBnFuUb7f6uLeQhhGJ0vEV4ntmtxKLT2WgXCO94E07BjunsIw1jOMPZw==",
 			"dev": true
 		},
 		"accepts": {
@@ -1934,24 +2055,32 @@
 			}
 		},
 		"acorn": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-			"integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q=="
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
 		},
 		"acorn-globals": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
-			"integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
 			"dev": true,
 			"requires": {
 				"acorn": "^6.0.1",
 				"acorn-walk": "^6.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+					"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+					"dev": true
+				}
 			}
 		},
 		"acorn-jsx": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-			"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
+			"integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
 			"dev": true
 		},
 		"acorn-walk": {
@@ -1961,9 +2090,9 @@
 			"dev": true
 		},
 		"address": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/address/-/address-1.1.0.tgz",
-			"integrity": "sha512-4diPfzWbLEIElVG4AnqP+00SULlPzNuyJFNnmMrLgyaxG6tZXJ1sn7mjBu4fHrJE+Yp/jgylOweJn2xsLMFggQ=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/address/-/address-1.1.2.tgz",
+			"integrity": "sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA=="
 		},
 		"airbnb-js-shims": {
 			"version": "2.2.0",
@@ -2009,6 +2138,11 @@
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
 			"integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
+		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
 		},
 		"ansi-align": {
 			"version": "3.0.0",
@@ -2074,6 +2208,14 @@
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"requires": {
 				"color-convert": "^1.9.0"
+			}
+		},
+		"ansi-to-html": {
+			"version": "0.6.11",
+			"resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.11.tgz",
+			"integrity": "sha512-88XZtrcwrfkyn6fGstHnkaF1kl7hGtNCYh4vSmItgEV+6JnQHryDBf7udF4f2RhTRQmYvJvPcTtqgaqrxzc9oA==",
+			"requires": {
+				"entities": "^1.1.1"
 			}
 		},
 		"anymatch": {
@@ -2297,9 +2439,9 @@
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
 		},
 		"ast-types": {
-			"version": "0.12.4",
-			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.4.tgz",
-			"integrity": "sha512-ky/YVYCbtVAS8TdMIaTiPFHwEpRB5z1hctepJplTr3UW5q8TDrpIMCILyk8pmLxGtn2KCtC/lSn7zOsaI7nzDw=="
+			"version": "0.9.6",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+			"integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
 		},
 		"ast-types-flow": {
 			"version": "0.0.7",
@@ -2327,9 +2469,9 @@
 			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
 		},
 		"async-limiter": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
 			"dev": true
 		},
 		"asynckit": {
@@ -2418,29 +2560,17 @@
 			}
 		},
 		"babel-eslint": {
-			"version": "10.0.2",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.2.tgz",
-			"integrity": "sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
+			"integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/parser": "^7.0.0",
 				"@babel/traverse": "^7.0.0",
 				"@babel/types": "^7.0.0",
-				"eslint-scope": "3.7.1",
-				"eslint-visitor-keys": "^1.0.0"
-			},
-			"dependencies": {
-				"eslint-scope": {
-					"version": "3.7.1",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-					"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-					"dev": true,
-					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
-					}
-				}
+				"eslint-visitor-keys": "^1.0.0",
+				"resolve": "^1.12.0"
 			}
 		},
 		"babel-helper-evaluate-path": {
@@ -2517,14 +2647,14 @@
 			}
 		},
 		"babel-plugin-emotion": {
-			"version": "10.0.14",
-			"resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.14.tgz",
-			"integrity": "sha512-T7hdxJ4xXkKW3OXcizK0pnUJlBeNj/emjQZPDIZvGOuwl2adIgicQWRNkz6BuwKdDTrqaXQn1vayaL6aL8QW5A==",
+			"version": "10.0.19",
+			"resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.19.tgz",
+			"integrity": "sha512-1pJb5uKN/gx6bi3gGr588Krj49sxARI9KmxhtMUa+NRJb6lR3OfC51mh3NlWRsOqdjWlT4cSjnZpnFq5K3T5ZA==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
-				"@emotion/hash": "0.7.2",
-				"@emotion/memoize": "0.7.2",
-				"@emotion/serialize": "^0.11.8",
+				"@emotion/hash": "0.7.3",
+				"@emotion/memoize": "0.7.3",
+				"@emotion/serialize": "^0.11.11",
 				"babel-plugin-macros": "^2.0.0",
 				"babel-plugin-syntax-jsx": "^6.18.0",
 				"convert-source-map": "^1.5.0",
@@ -2557,14 +2687,14 @@
 			}
 		},
 		"babel-plugin-minify-dead-code-elimination": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.0.tgz",
-			"integrity": "sha512-XQteBGXlgEoAKc/BhO6oafUdT4LBa7ARi55mxoyhLHNuA+RlzRmeMAfc31pb/UqU01wBzRc36YqHQzopnkd/6Q==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.1.tgz",
+			"integrity": "sha512-x8OJOZIrRmQBcSqxBcLbMIK8uPmTvNWPXH2bh5MDCW1latEqYiRMuUkPImKcfpo59pTUB2FT7HfcgtG8ZlR5Qg==",
 			"requires": {
 				"babel-helper-evaluate-path": "^0.5.0",
 				"babel-helper-mark-eval-scopes": "^0.4.3",
 				"babel-helper-remove-or-void": "^0.4.3",
-				"lodash.some": "^4.6.0"
+				"lodash": "^4.17.11"
 			}
 		},
 		"babel-plugin-minify-flip-comparisons": {
@@ -2576,10 +2706,11 @@
 			}
 		},
 		"babel-plugin-minify-guarded-expressions": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.3.tgz",
-			"integrity": "sha1-zHCbRFP9IbHzAod0RMifiEJ845c=",
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.4.tgz",
+			"integrity": "sha512-RMv0tM72YuPPfLT9QLr3ix9nwUIq+sHT6z8Iu3sLbqldzC1Dls8DPCywzUIzkTx9Zh1hWX4q/m9BPoPed9GOfA==",
 			"requires": {
+				"babel-helper-evaluate-path": "^0.5.0",
 				"babel-helper-flip-expressions": "^0.4.3"
 			}
 		},
@@ -2607,10 +2738,11 @@
 			"integrity": "sha512-aXZiaqWDNUbyNNNpWs/8NyST+oU7QTpK7J9zFEFSA0eOmtUNMU3fczlTTTlnCxHmq/jYNFEmkkSG3DDBtW3Y4Q=="
 		},
 		"babel-plugin-minify-simplify": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.0.tgz",
-			"integrity": "sha512-TM01J/YcKZ8XIQd1Z3nF2AdWHoDsarjtZ5fWPDksYZNsoOjQ2UO2EWm824Ym6sp127m44gPlLFiO5KFxU8pA5Q==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.1.tgz",
+			"integrity": "sha512-OSYDSnoCxP2cYDMk9gxNAed6uJDiDz65zgL6h8d3tm8qXIagWGMLWhqysT6DY3Vs7Fgq7YUDcjOomhVUb+xX6A==",
 			"requires": {
+				"babel-helper-evaluate-path": "^0.5.0",
 				"babel-helper-flip-expressions": "^0.4.3",
 				"babel-helper-is-nodes-equiv": "^0.0.1",
 				"babel-helper-to-multiple-sequence-expressions": "^0.5.0"
@@ -2625,9 +2757,9 @@
 			}
 		},
 		"babel-plugin-named-asset-import": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.2.tgz",
-			"integrity": "sha512-CxwvxrZ9OirpXQ201Ec57OmGhmI8/ui/GwTDy0hSp6CmRvgRC0pSair6Z04Ck+JStA0sMPZzSJ3uE4n17EXpPQ=="
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.3.tgz",
+			"integrity": "sha512-1XDRysF4894BUdMChT+2HHbtJYiO7zx5Be7U6bT8dISy7OdyETMGIAQBMPQCsY1YRf0xcubwnKKaDr5bk15JTA=="
 		},
 		"babel-plugin-react-docgen": {
 			"version": "3.1.0",
@@ -2637,6 +2769,29 @@
 				"lodash": "^4.17.11",
 				"react-docgen": "^4.1.0",
 				"recast": "^0.14.7"
+			},
+			"dependencies": {
+				"ast-types": {
+					"version": "0.11.3",
+					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.3.tgz",
+					"integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA=="
+				},
+				"recast": {
+					"version": "0.14.7",
+					"resolved": "https://registry.npmjs.org/recast/-/recast-0.14.7.tgz",
+					"integrity": "sha512-/nwm9pkrcWagN40JeJhkPaRxiHXBRkXyRh/hgU088Z/v+qCy+zIHHY6bC6o7NaKAxPqtE6nD8zBH1LfU0/Wx6A==",
+					"requires": {
+						"ast-types": "0.11.3",
+						"esprima": "~4.0.0",
+						"private": "~0.1.5",
+						"source-map": "~0.6.1"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"babel-plugin-syntax-jsx": {
@@ -2711,20 +2866,20 @@
 			"integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA="
 		},
 		"babel-preset-minify": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.5.0.tgz",
-			"integrity": "sha512-xj1s9Mon+RFubH569vrGCayA9Fm2GMsCgDRm1Jb8SgctOB7KFcrVc2o8K3YHUyMz+SWP8aea75BoS8YfsXXuiA==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.5.1.tgz",
+			"integrity": "sha512-1IajDumYOAPYImkHbrKeiN5AKKP9iOmRoO2IPbIuVp0j2iuCcj0n7P260z38siKMZZ+85d3mJZdtW8IgOv+Tzg==",
 			"requires": {
 				"babel-plugin-minify-builtins": "^0.5.0",
 				"babel-plugin-minify-constant-folding": "^0.5.0",
-				"babel-plugin-minify-dead-code-elimination": "^0.5.0",
+				"babel-plugin-minify-dead-code-elimination": "^0.5.1",
 				"babel-plugin-minify-flip-comparisons": "^0.4.3",
-				"babel-plugin-minify-guarded-expressions": "^0.4.3",
+				"babel-plugin-minify-guarded-expressions": "^0.4.4",
 				"babel-plugin-minify-infinity": "^0.4.3",
 				"babel-plugin-minify-mangle-names": "^0.5.0",
 				"babel-plugin-minify-numeric-literals": "^0.4.3",
 				"babel-plugin-minify-replace": "^0.5.0",
-				"babel-plugin-minify-simplify": "^0.5.0",
+				"babel-plugin-minify-simplify": "^0.5.1",
 				"babel-plugin-minify-type-constructors": "^0.4.3",
 				"babel-plugin-transform-inline-consecutive-adds": "^0.4.3",
 				"babel-plugin-transform-member-expression-literals": "^6.9.4",
@@ -2737,210 +2892,130 @@
 				"babel-plugin-transform-remove-undefined": "^0.5.0",
 				"babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
 				"babel-plugin-transform-undefined-to-void": "^6.9.4",
-				"lodash.isplainobject": "^4.0.6"
+				"lodash": "^4.17.11"
 			}
 		},
 		"babel-preset-react-app": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-9.0.0.tgz",
-			"integrity": "sha512-YVsDA8HpAKklhFLJtl9+AgaxrDaor8gGvDFlsg1ByOS0IPGUovumdv4/gJiAnLcDmZmKlH6+9sVOz4NVW7emAg==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-9.0.1.tgz",
+			"integrity": "sha512-v7MeY+QxdBhM9oU5uOQCIHLsErYkEbbjctXsb10II+KAnttbe0rvprvP785dRxfa9dI4ZbsGXsRU07Qdi5BtOw==",
 			"requires": {
-				"@babel/core": "7.4.3",
-				"@babel/plugin-proposal-class-properties": "7.4.0",
-				"@babel/plugin-proposal-decorators": "7.4.0",
-				"@babel/plugin-proposal-object-rest-spread": "7.4.3",
+				"@babel/core": "7.5.5",
+				"@babel/plugin-proposal-class-properties": "7.5.5",
+				"@babel/plugin-proposal-decorators": "7.4.4",
+				"@babel/plugin-proposal-object-rest-spread": "7.5.5",
 				"@babel/plugin-syntax-dynamic-import": "7.2.0",
-				"@babel/plugin-transform-classes": "7.4.3",
-				"@babel/plugin-transform-destructuring": "7.4.3",
-				"@babel/plugin-transform-flow-strip-types": "7.4.0",
-				"@babel/plugin-transform-react-constant-elements": "7.2.0",
+				"@babel/plugin-transform-destructuring": "7.5.0",
+				"@babel/plugin-transform-flow-strip-types": "7.4.4",
 				"@babel/plugin-transform-react-display-name": "7.2.0",
-				"@babel/plugin-transform-runtime": "7.4.3",
-				"@babel/preset-env": "7.4.3",
+				"@babel/plugin-transform-runtime": "7.5.5",
+				"@babel/preset-env": "7.5.5",
 				"@babel/preset-react": "7.0.0",
 				"@babel/preset-typescript": "7.3.3",
-				"@babel/runtime": "7.4.3",
-				"babel-plugin-dynamic-import-node": "2.2.0",
-				"babel-plugin-macros": "2.5.1",
+				"@babel/runtime": "7.5.5",
+				"babel-plugin-dynamic-import-node": "2.3.0",
+				"babel-plugin-macros": "2.6.1",
 				"babel-plugin-transform-react-remove-prop-types": "0.4.24"
 			},
 			"dependencies": {
 				"@babel/core": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
-					"integrity": "sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==",
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
+					"integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
 					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.4.0",
-						"@babel/helpers": "^7.4.3",
-						"@babel/parser": "^7.4.3",
-						"@babel/template": "^7.4.0",
-						"@babel/traverse": "^7.4.3",
-						"@babel/types": "^7.4.0",
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.5.5",
+						"@babel/helpers": "^7.5.5",
+						"@babel/parser": "^7.5.5",
+						"@babel/template": "^7.4.4",
+						"@babel/traverse": "^7.5.5",
+						"@babel/types": "^7.5.5",
 						"convert-source-map": "^1.1.0",
 						"debug": "^4.1.0",
 						"json5": "^2.1.0",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.13",
 						"resolve": "^1.3.2",
 						"semver": "^5.4.1",
 						"source-map": "^0.5.0"
 					}
 				},
-				"@babel/plugin-proposal-class-properties": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.0.tgz",
-					"integrity": "sha512-t2ECPNOXsIeK1JxJNKmgbzQtoG27KIlVE61vTqX0DKR9E9sZlVVxWUtEW9D5FlZ8b8j7SBNCHY47GgPKCKlpPg==",
-					"requires": {
-						"@babel/helper-create-class-features-plugin": "^7.4.0",
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-proposal-object-rest-spread": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
-					"integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
-					}
-				},
-				"@babel/plugin-transform-classes": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
-					"integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
-					"requires": {
-						"@babel/helper-annotate-as-pure": "^7.0.0",
-						"@babel/helper-define-map": "^7.4.0",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-optimise-call-expression": "^7.0.0",
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/helper-replace-supers": "^7.4.0",
-						"@babel/helper-split-export-declaration": "^7.4.0",
-						"globals": "^11.1.0"
-					}
-				},
 				"@babel/plugin-transform-destructuring": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
-					"integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
+					"version": "7.5.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
+					"integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
 					"requires": {
 						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-flow-strip-types": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.0.tgz",
-					"integrity": "sha512-C4ZVNejHnfB22vI2TYN4RUp2oCmq6cSEAg4RygSvYZUECRqUu9O4PMEMNJ4wsemaRGg27BbgYctG4BZh+AgIHw==",
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/plugin-syntax-flow": "^7.2.0"
-					}
-				},
-				"@babel/plugin-transform-react-constant-elements": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.2.0.tgz",
-					"integrity": "sha512-YYQFg6giRFMsZPKUM9v+VcHOdfSQdz9jHCx3akAi3UYgyjndmdYGSXylQ/V+HswQt4fL8IklchD9HTsaOCrWQQ==",
-					"requires": {
-						"@babel/helper-annotate-as-pure": "^7.0.0",
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-runtime": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.3.tgz",
-					"integrity": "sha512-7Q61bU+uEI7bCUFReT1NKn7/X6sDQsZ7wL1sJ9IYMAO7cI+eg6x9re1cEw2fCRMbbTVyoeUKWSV1M6azEfKCfg==",
-					"requires": {
-						"@babel/helper-module-imports": "^7.0.0",
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"resolve": "^1.8.1",
-						"semver": "^5.5.1"
 					}
 				},
 				"@babel/preset-env": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.3.tgz",
-					"integrity": "sha512-FYbZdV12yHdJU5Z70cEg0f6lvtpZ8jFSDakTm7WXeJbLXh4R0ztGEu/SW7G1nJ2ZvKwDhz8YrbA84eYyprmGqw==",
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz",
+					"integrity": "sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==",
 					"requires": {
 						"@babel/helper-module-imports": "^7.0.0",
 						"@babel/helper-plugin-utils": "^7.0.0",
 						"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+						"@babel/plugin-proposal-dynamic-import": "^7.5.0",
 						"@babel/plugin-proposal-json-strings": "^7.2.0",
-						"@babel/plugin-proposal-object-rest-spread": "^7.4.3",
+						"@babel/plugin-proposal-object-rest-spread": "^7.5.5",
 						"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-						"@babel/plugin-proposal-unicode-property-regex": "^7.4.0",
+						"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
 						"@babel/plugin-syntax-async-generators": "^7.2.0",
+						"@babel/plugin-syntax-dynamic-import": "^7.2.0",
 						"@babel/plugin-syntax-json-strings": "^7.2.0",
 						"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
 						"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
 						"@babel/plugin-transform-arrow-functions": "^7.2.0",
-						"@babel/plugin-transform-async-to-generator": "^7.4.0",
+						"@babel/plugin-transform-async-to-generator": "^7.5.0",
 						"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-						"@babel/plugin-transform-block-scoping": "^7.4.0",
-						"@babel/plugin-transform-classes": "^7.4.3",
+						"@babel/plugin-transform-block-scoping": "^7.5.5",
+						"@babel/plugin-transform-classes": "^7.5.5",
 						"@babel/plugin-transform-computed-properties": "^7.2.0",
-						"@babel/plugin-transform-destructuring": "^7.4.3",
-						"@babel/plugin-transform-dotall-regex": "^7.4.3",
-						"@babel/plugin-transform-duplicate-keys": "^7.2.0",
+						"@babel/plugin-transform-destructuring": "^7.5.0",
+						"@babel/plugin-transform-dotall-regex": "^7.4.4",
+						"@babel/plugin-transform-duplicate-keys": "^7.5.0",
 						"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-						"@babel/plugin-transform-for-of": "^7.4.3",
-						"@babel/plugin-transform-function-name": "^7.4.3",
+						"@babel/plugin-transform-for-of": "^7.4.4",
+						"@babel/plugin-transform-function-name": "^7.4.4",
 						"@babel/plugin-transform-literals": "^7.2.0",
 						"@babel/plugin-transform-member-expression-literals": "^7.2.0",
-						"@babel/plugin-transform-modules-amd": "^7.2.0",
-						"@babel/plugin-transform-modules-commonjs": "^7.4.3",
-						"@babel/plugin-transform-modules-systemjs": "^7.4.0",
+						"@babel/plugin-transform-modules-amd": "^7.5.0",
+						"@babel/plugin-transform-modules-commonjs": "^7.5.0",
+						"@babel/plugin-transform-modules-systemjs": "^7.5.0",
 						"@babel/plugin-transform-modules-umd": "^7.2.0",
-						"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.2",
-						"@babel/plugin-transform-new-target": "^7.4.0",
-						"@babel/plugin-transform-object-super": "^7.2.0",
-						"@babel/plugin-transform-parameters": "^7.4.3",
+						"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
+						"@babel/plugin-transform-new-target": "^7.4.4",
+						"@babel/plugin-transform-object-super": "^7.5.5",
+						"@babel/plugin-transform-parameters": "^7.4.4",
 						"@babel/plugin-transform-property-literals": "^7.2.0",
-						"@babel/plugin-transform-regenerator": "^7.4.3",
+						"@babel/plugin-transform-regenerator": "^7.4.5",
 						"@babel/plugin-transform-reserved-words": "^7.2.0",
 						"@babel/plugin-transform-shorthand-properties": "^7.2.0",
 						"@babel/plugin-transform-spread": "^7.2.0",
 						"@babel/plugin-transform-sticky-regex": "^7.2.0",
-						"@babel/plugin-transform-template-literals": "^7.2.0",
+						"@babel/plugin-transform-template-literals": "^7.4.4",
 						"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-						"@babel/plugin-transform-unicode-regex": "^7.4.3",
-						"@babel/types": "^7.4.0",
-						"browserslist": "^4.5.2",
-						"core-js-compat": "^3.0.0",
+						"@babel/plugin-transform-unicode-regex": "^7.4.4",
+						"@babel/types": "^7.5.5",
+						"browserslist": "^4.6.0",
+						"core-js-compat": "^3.1.1",
 						"invariant": "^2.2.2",
 						"js-levenshtein": "^1.1.3",
 						"semver": "^5.5.0"
 					}
 				},
 				"@babel/runtime": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
-					"integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+					"integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
 				},
-				"babel-plugin-dynamic-import-node": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz",
-					"integrity": "sha512-fP899ELUnTaBcIzmrW7nniyqqdYWrWuJUyPWHxFa/c7r7hS6KC8FscNfLlBNIoPSc55kYMGEEKjPjJGCLbE1qA==",
-					"requires": {
-						"object.assign": "^4.1.0"
-					}
-				},
-				"babel-plugin-macros": {
-					"version": "2.5.1",
-					"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.5.1.tgz",
-					"integrity": "sha512-xN3KhAxPzsJ6OQTktCanNpIFnnMsCV+t8OloKxIL72D6+SUZYFn9qfklPgef5HyyDtzYZqqb+fs1S12+gQY82Q==",
-					"requires": {
-						"@babel/runtime": "^7.4.2",
-						"cosmiconfig": "^5.2.0",
-						"resolve": "^1.10.0"
-					}
-				},
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
 		},
@@ -3020,10 +3095,20 @@
 				}
 			}
 		},
+		"base62": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/base62/-/base62-1.2.8.tgz",
+			"integrity": "sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA=="
+		},
 		"base64-js": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+		},
+		"batch-processor": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
+			"integrity": "sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -3083,6 +3168,11 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"qs": {
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
 				}
 			}
 		},
@@ -3255,13 +3345,13 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.6.6",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
-			"integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
+			"integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
 			"requires": {
-				"caniuse-lite": "^1.0.30000984",
-				"electron-to-chromium": "^1.3.191",
-				"node-releases": "^1.1.25"
+				"caniuse-lite": "^1.0.30000989",
+				"electron-to-chromium": "^1.3.247",
+				"node-releases": "^1.1.29"
 			}
 		},
 		"buffer": {
@@ -3295,15 +3385,16 @@
 			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
 		},
 		"cacache": {
-			"version": "11.3.3",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
-			"integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
+			"version": "12.0.3",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+			"integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
 			"requires": {
 				"bluebird": "^3.5.5",
 				"chownr": "^1.1.1",
 				"figgy-pudding": "^3.5.1",
 				"glob": "^7.1.4",
 				"graceful-fs": "^4.1.15",
+				"infer-owner": "^1.0.3",
 				"lru-cache": "^5.1.1",
 				"mississippi": "^3.0.0",
 				"mkdirp": "^0.5.1",
@@ -3315,6 +3406,19 @@
 				"y18n": "^4.0.0"
 			},
 			"dependencies": {
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
 				"lru-cache": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3392,9 +3496,9 @@
 			"integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo="
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000986",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000986.tgz",
-			"integrity": "sha512-pM+LnkoAX0+QnIH3tpW5EnkmfpEoqOD8FAcoBvsl3Xh6DXkgctiCxeCbXphP/k3XJtJzm+zOAJbi6U6IVkpWZQ=="
+			"version": "1.0.30000989",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
+			"integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw=="
 		},
 		"case-sensitive-paths-webpack-plugin": {
 			"version": "2.2.0",
@@ -3430,11 +3534,6 @@
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
 			}
-		},
-		"change-emitter": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
 		},
 		"character-entities": {
 			"version": "1.2.3",
@@ -3474,12 +3573,24 @@
 				"htmlparser2": "^3.9.1",
 				"lodash": "^4.15.0",
 				"parse5": "^3.0.1"
+			},
+			"dependencies": {
+				"dom-serializer": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+					"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^1.3.0",
+						"entities": "^1.1.1"
+					}
+				}
 			}
 		},
 		"chokidar": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
-			"integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+			"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
 			"requires": {
 				"anymatch": "^2.0.0",
 				"async-each": "^1.0.1",
@@ -3772,6 +3883,22 @@
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
 		},
+		"commoner": {
+			"version": "0.10.8",
+			"resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+			"integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
+			"requires": {
+				"commander": "^2.5.0",
+				"detective": "^4.3.1",
+				"glob": "^5.0.15",
+				"graceful-fs": "^4.1.2",
+				"iconv-lite": "^0.4.5",
+				"mkdirp": "^0.5.0",
+				"private": "^0.1.6",
+				"q": "^1.1.2",
+				"recast": "^0.11.17"
+			}
+		},
 		"component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -3794,9 +3921,9 @@
 			}
 		},
 		"confusing-browser-globals": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz",
-			"integrity": "sha512-cgHI1azax5ATrZ8rJ+ODDML9Fvu67PimB6aNxBrc/QwSaDaM9eTfIEUHx3bBLJJ82ioSb+/5zfsMCCEJax3ByQ==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.8.tgz",
+			"integrity": "sha512-lI7asCibVJ6Qd3FGU7mu4sfG4try4LX3+GVS+Gv8UlrEf2AeW57piecapnog2UHZSbcX/P/1UDWVaTsblowlZg==",
 			"dev": true
 		},
 		"console-browserify": {
@@ -3886,19 +4013,18 @@
 			"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
 		},
 		"core-js-compat": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
-			"integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
+			"integrity": "sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==",
 			"requires": {
-				"browserslist": "^4.6.2",
-				"core-js-pure": "3.1.4",
-				"semver": "^6.1.1"
+				"browserslist": "^4.6.6",
+				"semver": "^6.3.0"
 			}
 		},
 		"core-js-pure": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
-			"integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA=="
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.2.1.tgz",
+			"integrity": "sha512-+qpvnYrsi/JDeQTArB7NnNc2VoMYLE1YSkziCDHgjexC2KH7OFiGhLUd3urxfyWmNjSwSW7NYXPWHMhuIJx9Ow=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -3906,12 +4032,12 @@
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"corejs-upgrade-webpack-plugin": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/corejs-upgrade-webpack-plugin/-/corejs-upgrade-webpack-plugin-2.1.0.tgz",
-			"integrity": "sha512-gc+S4t8VT9YFSgOPrhZlD6kDoGZtUq71QwXxS2neGNPhli0veKhbzzilODIpy73TjXGUrCHCpevK8vBnzUPuhw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/corejs-upgrade-webpack-plugin/-/corejs-upgrade-webpack-plugin-2.2.0.tgz",
+			"integrity": "sha512-J0QMp9GNoiw91Kj/dkIQFZeiCXgXoja/Wlht1SPybxerBWh4NCmb0pOgCv61lrlQZETwvVVfAFAA3IqoEO9aqQ==",
 			"requires": {
 				"resolve-from": "^5.0.0",
-				"webpack": "^4.33.0"
+				"webpack": "^4.38.0"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -4015,27 +4141,32 @@
 			}
 		},
 		"css-loader": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-2.1.1.tgz",
-			"integrity": "sha512-OcKJU/lt232vl1P9EEDamhoO9iKY3tIjY5GU+XDLblAykTdgs6Ux9P1hTHve8nFKy5KPpOXOsVI/hIwi3841+w==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.2.0.tgz",
+			"integrity": "sha512-QTF3Ud5H7DaZotgdcJjGMvyDj5F3Pn1j/sC6VBEOVp94cbwqyIBdcs/quzj4MC1BKQSrTpQznegH/5giYbhnCQ==",
 			"requires": {
-				"camelcase": "^5.2.0",
-				"icss-utils": "^4.1.0",
+				"camelcase": "^5.3.1",
+				"cssesc": "^3.0.0",
+				"icss-utils": "^4.1.1",
 				"loader-utils": "^1.2.3",
 				"normalize-path": "^3.0.0",
-				"postcss": "^7.0.14",
+				"postcss": "^7.0.17",
 				"postcss-modules-extract-imports": "^2.0.0",
-				"postcss-modules-local-by-default": "^2.0.6",
+				"postcss-modules-local-by-default": "^3.0.2",
 				"postcss-modules-scope": "^2.1.0",
-				"postcss-modules-values": "^2.0.0",
-				"postcss-value-parser": "^3.3.0",
-				"schema-utils": "^1.0.0"
+				"postcss-modules-values": "^3.0.0",
+				"postcss-value-parser": "^4.0.0",
+				"schema-utils": "^2.0.0"
 			},
 			"dependencies": {
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+				"schema-utils": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.2.0.tgz",
+					"integrity": "sha512-5EwsCNhfFTZvUreQhx/4vVQpJ/lnCAkgoIHLhSpp4ZirE+4hzFvdJi0FMub6hxbFVBJYSpeVVmon+2e7uEGRrA==",
+					"requires": {
+						"ajv": "^6.10.2",
+						"ajv-keywords": "^3.4.1"
+					}
 				}
 			}
 		},
@@ -4119,9 +4250,9 @@
 			"integrity": "sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg=="
 		},
 		"cyclist": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
+			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
 		},
 		"damerau-levenshtein": {
 			"version": "1.0.5",
@@ -4238,6 +4369,11 @@
 				}
 			}
 		},
+		"defined": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -4298,6 +4434,15 @@
 				}
 			}
 		},
+		"detective": {
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+			"integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+			"requires": {
+				"acorn": "^5.2.1",
+				"defined": "^1.0.0"
+			}
+		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -4345,13 +4490,33 @@
 				"utila": "~0.4"
 			}
 		},
-		"dom-serializer": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-			"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+		"dom-helpers": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+			"integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
 			"requires": {
-				"domelementtype": "^1.3.0",
-				"entities": "^1.1.1"
+				"@babel/runtime": "^7.1.2"
+			}
+		},
+		"dom-serializer": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
+			"integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
+			"requires": {
+				"domelementtype": "^2.0.1",
+				"entities": "^2.0.0"
+			},
+			"dependencies": {
+				"domelementtype": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+					"integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+				},
+				"entities": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+					"integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+				}
 			}
 		},
 		"dom-walk": {
@@ -4453,19 +4618,27 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"ejs": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
-			"integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q=="
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.1.tgz",
+			"integrity": "sha512-kS/gEPzZs3Y1rRsbGX4UOSjtP/CeJP0CxSNZHYxGfVM/VgLcv0ZqM7C45YyTj2DI2g7+P9Dd24C+IMIg6D0nYQ=="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.201",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.201.tgz",
-			"integrity": "sha512-aCTPIfY1Jvuam5b6vuWRjt1F8i4kY7zX0Qtpu5SNd6l1zjuxU9fDNpbM4o6+oJsra+TMD2o7D20GnkSIgpTr9w=="
+			"version": "1.3.260",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.260.tgz",
+			"integrity": "sha512-wGt+OivF1C1MPwaSv3LJ96ebNbLAWlx3HndivDDWqwIVSQxmhL17Y/YmwUdEMtS/bPyommELt47Dct0/VZNQBQ=="
+		},
+		"element-resize-detector": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.1.15.tgz",
+			"integrity": "sha512-16/5avDegXlUxytGgaumhjyQoM6hpp5j3+L79sYq5hlXfTNRy5WMMuTVWkZU3egp/CokCmTmvf18P3KeB57Iog==",
+			"requires": {
+				"batch-processor": "^1.0.0"
+			}
 		},
 		"elliptic": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
-			"integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+			"integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -4487,12 +4660,12 @@
 			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
 		},
 		"emotion-theming": {
-			"version": "10.0.14",
-			"resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-10.0.14.tgz",
-			"integrity": "sha512-zMGhPSYz48AAR6DYjQVaZHeO42cYKPq4VyB1XjxzgR62/NmO99679fx8qDDB1QZVYGkRWZtsOe+zJE/e30XdbA==",
+			"version": "10.0.19",
+			"resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-10.0.19.tgz",
+			"integrity": "sha512-dQRBPLAAQ6eA8JKhkLCIWC8fdjPbiNC1zNTdFF292h9amhZXofcNGUP7axHoHX4XesqQESYwZrXp53OPInMrKw==",
 			"requires": {
-				"@babel/runtime": "^7.4.3",
-				"@emotion/weak-memoize": "0.2.3",
+				"@babel/runtime": "^7.5.5",
+				"@emotion/weak-memoize": "0.2.4",
 				"hoist-non-react-statics": "^3.3.0"
 			}
 		},
@@ -4531,6 +4704,15 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
 			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+		},
+		"envify": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
+			"integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
+			"requires": {
+				"jstransform": "^11.0.3",
+				"through": "~2.3.4"
+			}
 		},
 		"enzyme": {
 			"version": "3.10.0",
@@ -4578,16 +4760,20 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+			"version": "1.14.2",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
+			"integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
 			"requires": {
 				"es-to-primitive": "^1.2.0",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
+				"has-symbols": "^1.0.0",
 				"is-callable": "^1.1.4",
 				"is-regex": "^1.0.4",
-				"object-keys": "^1.0.12"
+				"object-inspect": "^1.6.0",
+				"object-keys": "^1.1.1",
+				"string.prototype.trimleft": "^2.0.0",
+				"string.prototype.trimright": "^2.0.0"
 			}
 		},
 		"es-to-primitive": {
@@ -4621,9 +4807,9 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
-			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+			"integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
 			"dev": true,
 			"requires": {
 				"esprima": "^3.1.3",
@@ -4649,9 +4835,9 @@
 			}
 		},
 		"eslint": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.1.0.tgz",
-			"integrity": "sha512-QhrbdRD7ofuV09IuE2ySWBz0FyXCq0rriLTZXZqaWSI79CVtHVRdkFuFTViiqzZhkCgfOh9USpriuGN2gIpZDQ==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.4.0.tgz",
+			"integrity": "sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
@@ -4661,9 +4847,9 @@
 				"debug": "^4.0.1",
 				"doctrine": "^3.0.0",
 				"eslint-scope": "^5.0.0",
-				"eslint-utils": "^1.3.1",
-				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^6.0.0",
+				"eslint-utils": "^1.4.2",
+				"eslint-visitor-keys": "^1.1.0",
+				"espree": "^6.1.1",
 				"esquery": "^1.0.1",
 				"esutils": "^2.0.2",
 				"file-entry-cache": "^5.0.1",
@@ -4713,9 +4899,9 @@
 					},
 					"dependencies": {
 						"semver": {
-							"version": "5.7.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+							"version": "5.7.1",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 							"dev": true
 						}
 					}
@@ -5016,29 +5202,37 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-			"integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
 			"dev": true,
 			"requires": {
 				"eslint-visitor-keys": "^1.0.0"
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
 			"dev": true
 		},
 		"espree": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz",
-			"integrity": "sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
+			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^6.0.7",
-				"acorn-jsx": "^5.0.0",
-				"eslint-visitor-keys": "^1.0.0"
+				"acorn": "^7.0.0",
+				"acorn-jsx": "^5.0.2",
+				"eslint-visitor-keys": "^1.1.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
+					"integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+					"dev": true
+				}
 			}
 		},
 		"esprima": {
@@ -5064,14 +5258,14 @@
 			}
 		},
 		"estraverse": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
 		},
 		"esutils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -5079,9 +5273,9 @@
 			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
 		},
 		"eventemitter3": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-			"integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+			"integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
 		},
 		"events": {
 			"version": "3.0.0",
@@ -5213,6 +5407,11 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"qs": {
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
 				}
 			}
 		},
@@ -5597,6 +5796,31 @@
 				"flatted": "^2.0.0",
 				"rimraf": "2.6.3",
 				"write": "1.0.3"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"flatted": {
@@ -5639,9 +5863,9 @@
 			"dev": true
 		},
 		"fork-ts-checker-webpack-plugin": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.1.1.tgz",
-			"integrity": "sha512-gqWAEMLlae/oeVnN6RWCAhesOJMswAN1MaKNqhhjXHV5O0/rTUjWI4UbgQHdlrVbCnb+xLotXmJbBlC66QmpFw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.5.0.tgz",
+			"integrity": "sha512-zEhg7Hz+KhZlBhILYpXy+Beu96gwvkROWJiTXOCyOOMMrdBIRPvsBpBqgTI4jfJGrJXcqGwJR8zsBGDmzY0jsA==",
 			"requires": {
 				"babel-code-frame": "^6.22.0",
 				"chalk": "^2.4.1",
@@ -5654,9 +5878,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
 		},
@@ -6266,11 +6490,6 @@
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
 			"dev": true
 		},
-		"get-own-enumerable-property-symbols": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
-			"integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg=="
-		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -6310,14 +6529,13 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "5.0.15",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+			"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
 			"requires": {
-				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
+				"minimatch": "2 || 3",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			}
@@ -6402,6 +6620,19 @@
 				"slash": "^1.0.0"
 			},
 			"dependencies": {
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -6419,9 +6650,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-			"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+			"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
 		},
 		"growl": {
 			"version": "1.10.5",
@@ -6435,19 +6666,12 @@
 			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
 		},
 		"gzip-size": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
-			"integrity": "sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
+			"integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
 			"requires": {
 				"duplexer": "^0.1.1",
-				"pify": "^3.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				}
+				"pify": "^4.0.1"
 			}
 		},
 		"har-schema": {
@@ -6589,9 +6813,9 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+			"integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
 			"dev": true
 		},
 		"html-element-map": {
@@ -6725,11 +6949,6 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
-		"icss-replace-symbols": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
-		},
 		"icss-utils": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
@@ -6757,6 +6976,11 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
 			"integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg=="
+		},
+		"immutable": {
+			"version": "4.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.12.tgz",
+			"integrity": "sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A=="
 		},
 		"import-cwd": {
 			"version": "2.1.0",
@@ -6793,6 +7017,11 @@
 			"resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
 			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
 		},
+		"infer-owner": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+			"integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
+		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -6813,9 +7042,9 @@
 			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inquirer": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-			"integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+			"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
 			"requires": {
 				"ansi-escapes": "^3.2.0",
 				"chalk": "^2.4.2",
@@ -7024,6 +7253,15 @@
 			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
 			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
 		},
+		"is-dom": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-dom/-/is-dom-1.1.0.tgz",
+			"integrity": "sha512-u82f6mvhYxRPKpw8V1N0W8ce1xXwOrQtgGcxl6UCL5zBmZu3is/18K0rR7uFCnMDuAsS/3W54mGL4vsaFUQlEQ==",
+			"requires": {
+				"is-object": "^1.0.1",
+				"is-window": "^1.0.2"
+			}
+		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -7084,10 +7322,10 @@
 			"integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
 			"dev": true
 		},
-		"is-obj": {
+		"is-object": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
@@ -7122,15 +7360,10 @@
 				"has": "^1.0.1"
 			}
 		},
-		"is-regexp": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
-		},
 		"is-root": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-root/-/is-root-2.0.0.tgz",
-			"integrity": "sha512-F/pJIk8QD6OX5DNhRB7hWamLsUilmkDGho48KbgZ6xg/lmAZXHxzXQ91jzB3yRSw5kdQGGGc4yz8HYhTYIMWPg=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
+			"integrity": "sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg=="
 		},
 		"is-ssh": {
 			"version": "1.3.1",
@@ -7171,6 +7404,11 @@
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 			"dev": true
+		},
+		"is-window": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-window/-/is-window-1.0.2.tgz",
+			"integrity": "sha1-LIlspT25feRdPDMTOmXYyfVjSA0="
 		},
 		"is-windows": {
 			"version": "1.0.2",
@@ -7271,6 +7509,12 @@
 				"xml-name-validator": "^3.0.0"
 			},
 			"dependencies": {
+				"acorn": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+					"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+					"dev": true
+				},
 				"parse5": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
@@ -7306,6 +7550,11 @@
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
 		},
+		"json-stringify-pretty-compact": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-1.2.0.tgz",
+			"integrity": "sha512-/11Pj1OyX814QMKO7K8l85SHPTr/KsFxHp8GE2zVa0BtJgGimDjXHfM3FhC7keQdWDea7+nXf+f1de7ATZcZkQ=="
+		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -7323,6 +7572,13 @@
 			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
 			"requires": {
 				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
 			}
 		},
 		"jsonfile": {
@@ -7350,6 +7606,38 @@
 				"verror": "1.10.0"
 			}
 		},
+		"jstransform": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
+			"integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
+			"requires": {
+				"base62": "^1.1.0",
+				"commoner": "^0.10.1",
+				"esprima-fb": "^15001.1.0-dev-harmony-fb",
+				"object-assign": "^2.0.0",
+				"source-map": "^0.4.2"
+			},
+			"dependencies": {
+				"esprima-fb": {
+					"version": "15001.1.0-dev-harmony-fb",
+					"resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+					"integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
+				},
+				"object-assign": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+				},
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"requires": {
+						"amdefine": ">=0.0.4"
+					}
+				}
+			}
+		},
 		"jsx-ast-utils": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
@@ -7358,6 +7646,49 @@
 			"requires": {
 				"array-includes": "^3.0.3",
 				"object.assign": "^4.1.0"
+			}
+		},
+		"jsx-to-string": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/jsx-to-string/-/jsx-to-string-1.4.0.tgz",
+			"integrity": "sha1-Ztw013PaufQP6ZPP+ZQOXaZVtwU=",
+			"requires": {
+				"immutable": "^4.0.0-rc.9",
+				"json-stringify-pretty-compact": "^1.0.1",
+				"react": "^0.14.0"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				},
+				"fbjs": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.6.1.tgz",
+					"integrity": "sha1-lja3cF9bqWhNRLcveDISVK/IYPc=",
+					"requires": {
+						"core-js": "^1.0.0",
+						"loose-envify": "^1.0.0",
+						"promise": "^7.0.3",
+						"ua-parser-js": "^0.7.9",
+						"whatwg-fetch": "^0.9.0"
+					}
+				},
+				"react": {
+					"version": "0.14.9",
+					"resolved": "https://registry.npmjs.org/react/-/react-0.14.9.tgz",
+					"integrity": "sha1-kRCmSXxJ1EuhwO3TF67CnC4NkdE=",
+					"requires": {
+						"envify": "^3.0.0",
+						"fbjs": "^0.6.1"
+					}
+				},
+				"whatwg-fetch": {
+					"version": "0.9.0",
+					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
+					"integrity": "sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA="
+				}
 			}
 		},
 		"just-extend": {
@@ -7385,11 +7716,11 @@
 			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
 		},
 		"lazy-universal-dotenv": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lazy-universal-dotenv/-/lazy-universal-dotenv-3.0.0.tgz",
-			"integrity": "sha512-Mbf5AeGOs74lE5BdQXHFJ7Rt383jxnWKNfW2EWL0Pibnhea5JRStRIiUpdTenyMxCGuCjlMpYQhhay1XZBSSQA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lazy-universal-dotenv/-/lazy-universal-dotenv-3.0.1.tgz",
+			"integrity": "sha512-prXSYk799h3GY3iOWnC6ZigYzMPjxN2svgjJ9shk7oMadSNX3wXy0B6F32PMJv7qtMnrIbUxoEHzbutvxR2LBQ==",
 			"requires": {
-				"@babel/runtime": "^7.0.0",
+				"@babel/runtime": "^7.5.0",
 				"app-root-dir": "^1.0.2",
 				"core-js": "^3.0.4",
 				"dotenv": "^8.0.0",
@@ -7397,14 +7728,14 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				},
 				"dotenv": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
-					"integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg=="
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.1.0.tgz",
+					"integrity": "sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA=="
 				}
 			}
 		},
@@ -7478,6 +7809,11 @@
 					"requires": {
 						"minimist": "^1.2.0"
 					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
 		},
@@ -7494,11 +7830,6 @@
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-		},
-		"lodash-es": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-			"integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
 		},
 		"lodash.debounce": {
 			"version": "4.0.8",
@@ -7523,20 +7854,10 @@
 			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
 			"dev": true
 		},
-		"lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
 			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
-		},
-		"lodash.some": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-			"integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
@@ -7559,9 +7880,9 @@
 			}
 		},
 		"lolex": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
-			"integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+			"integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
 			"dev": true
 		},
 		"loose-envify": {
@@ -7605,9 +7926,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
 		},
@@ -7644,9 +7965,9 @@
 			}
 		},
 		"markdown-to-jsx": {
-			"version": "6.10.2",
-			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.10.2.tgz",
-			"integrity": "sha512-eDCsRobOkbQ4PqCphrxNi/U8geA8DGf52dMP4BrrYsVFyQ2ILFnXIB5sRcIxnRK2nPl8k5hUYdRNRXLlQNYLYg==",
+			"version": "6.10.3",
+			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.10.3.tgz",
+			"integrity": "sha512-PSoUyLnW/xoW6RsxZrquSSz5eGEOTwa15H5eqp3enmrp8esmgDJmhzd6zmQ9tgAA9TxJzx1Hmf3incYU/IamoQ==",
 			"requires": {
 				"prop-types": "^15.6.2",
 				"unquote": "^1.1.0"
@@ -7673,6 +7994,11 @@
 					"integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
 				}
 			}
+		},
+		"material-colors": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
+			"integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -7712,6 +8038,11 @@
 					"dev": true
 				}
 			}
+		},
+		"memoize-one": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+			"integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
 		},
 		"memoizerific": {
 			"version": "1.11.3",
@@ -7756,9 +8087,9 @@
 			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
 		},
 		"merge2": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-			"integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw=="
 		},
 		"methods": {
 			"version": "1.1.2",
@@ -7860,9 +8191,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mississippi": {
 			"version": "3.0.0",
@@ -7930,13 +8261,6 @@
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"requires": {
 				"minimist": "0.0.8"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-				}
 			}
 		},
 		"mocha": {
@@ -8082,9 +8406,9 @@
 			"dev": true
 		},
 		"nearley": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
-			"integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.0.tgz",
+			"integrity": "sha512-2v52FTw7RPqieZr3Gth1luAXZR7Je6q3KaDHY5bjl/paDUdMu35fZ8ICNgiYJRr3tf3NMvIQQR1r27AvEr9CRA==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
@@ -8095,9 +8419,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
 				}
 			}
@@ -8123,12 +8447,12 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
 		"nise": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
-			"integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+			"integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "^3.1.0",
+				"@sinonjs/formatio": "^3.2.1",
 				"@sinonjs/text-encoding": "^0.7.1",
 				"just-extend": "^4.0.2",
 				"lolex": "^4.1.0",
@@ -8179,9 +8503,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
 				}
 			}
@@ -8239,17 +8563,17 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "1.1.26",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-			"integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
+			"version": "1.1.32",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.32.tgz",
+			"integrity": "sha512-VhVknkitq8dqtWoluagsGPn3dxTvN9fwgR59fV3D7sLBHe0JfDramsMI8n8mY//ccq/Kkrf8ZRHRpsyVZ3qw1A==",
 			"requires": {
 				"semver": "^5.3.0"
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
 		},
@@ -8266,9 +8590,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
 				}
 			}
@@ -8379,8 +8703,7 @@
 		"object-inspect": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
-			"dev": true
+			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
 		},
 		"object-is": {
 			"version": "1.0.1",
@@ -8494,14 +8817,6 @@
 				"is-wsl": "^1.1.0"
 			}
 		},
-		"opn": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
-			"integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
-			"requires": {
-				"is-wsl": "^1.1.0"
-			}
-		},
 		"optionator": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -8578,9 +8893,9 @@
 					}
 				},
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
 				}
 			}
@@ -8619,9 +8934,9 @@
 			"dev": true
 		},
 		"p-limit": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-			"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+			"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 			"requires": {
 				"p-try": "^2.0.0"
 			}
@@ -8645,11 +8960,11 @@
 			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
 		},
 		"parallel-transform": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
+			"integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
 			"requires": {
-				"cyclist": "~0.2.2",
+				"cyclist": "^1.0.1",
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.1.5"
 			}
@@ -8834,8 +9149,7 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"pify": {
 			"version": "4.0.1",
@@ -8940,9 +9254,9 @@
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"postcss": {
-			"version": "7.0.17",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-			"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
+			"version": "7.0.18",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
+			"integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
 			"requires": {
 				"chalk": "^2.4.2",
 				"source-map": "^0.6.1",
@@ -9001,20 +9315,14 @@
 			}
 		},
 		"postcss-modules-local-by-default": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.6.tgz",
-			"integrity": "sha512-oLUV5YNkeIBa0yQl7EYnxMgy4N6noxmiwZStaEJUSe2xPMcdNc8WmBQuQCx18H5psYbVxz8zoHk0RAAYZXP9gA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.2.tgz",
+			"integrity": "sha512-jM/V8eqM4oJ/22j0gx4jrp63GSvDH6v86OqyTHHUvk4/k1vceipZsaymiZ5PvocqZOl5SFHiFJqjs3la0wnfIQ==",
 			"requires": {
-				"postcss": "^7.0.6",
-				"postcss-selector-parser": "^6.0.0",
-				"postcss-value-parser": "^3.3.1"
-			},
-			"dependencies": {
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
-				}
+				"icss-utils": "^4.1.1",
+				"postcss": "^7.0.16",
+				"postcss-selector-parser": "^6.0.2",
+				"postcss-value-parser": "^4.0.0"
 			}
 		},
 		"postcss-modules-scope": {
@@ -9027,11 +9335,11 @@
 			}
 		},
 		"postcss-modules-values": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-2.0.0.tgz",
-			"integrity": "sha512-Ki7JZa7ff1N3EIMlPnGTZfUMe69FFwiQPnVSXC9mnn3jozCRBYIxiZd44yJOV2AmabOo4qFf8s0dC/+lweG7+w==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
+			"integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
 			"requires": {
-				"icss-replace-symbols": "^1.1.0",
+				"icss-utils": "^4.0.0",
 				"postcss": "^7.0.6"
 			}
 		},
@@ -9046,9 +9354,9 @@
 			}
 		},
 		"postcss-value-parser": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.0.tgz",
-			"integrity": "sha512-ESPktioptiSUchCKgggAkzdmkgzKfmp0EU8jXH+5kbIUB+unr0Y4CY9SRMvibuvYUBjNh1ACLbxqYNpdTQOteQ=="
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+			"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ=="
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
@@ -9128,12 +9436,12 @@
 			}
 		},
 		"promise.prototype.finally": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz",
-			"integrity": "sha512-7p/K2f6dI+dM8yjRQEGrTQs5hTQixUAdOGpMEA3+pVxpX5oHKRSKAXyLw9Q9HUWDTdwtoo39dSHGQtN90HcEwQ==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.1.tgz",
+			"integrity": "sha512-gnt8tThx0heJoI3Ms8a/JdkYBVhYP/wv+T7yQimR+kdOEJL21xTFbiJhMRqnSPcr54UVvMbsscDk2w+ivyaLPw==",
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.9.0",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.13.0",
 				"function-bind": "^1.1.1"
 			}
 		},
@@ -9181,9 +9489,9 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"psl": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
-			"integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+			"integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
 			"dev": true
 		},
 		"public-encrypt": {
@@ -9240,9 +9548,9 @@
 			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
 		},
 		"qs": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-			"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+			"version": "6.8.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.8.0.tgz",
+			"integrity": "sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w=="
 		},
 		"query-string": {
 			"version": "4.3.4",
@@ -9272,15 +9580,9 @@
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
 			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-			"dev": true,
 			"requires": {
 				"performance-now": "^2.1.0"
 			}
-		},
-		"raf-schd": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.2.tgz",
-			"integrity": "sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ=="
 		},
 		"railroad-diagrams": {
 			"version": "1.0.0",
@@ -9346,14 +9648,13 @@
 			}
 		},
 		"react": {
-			"version": "16.8.6",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-			"integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+			"version": "16.9.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
+			"integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"scheduler": "^0.13.6"
+				"prop-types": "^15.6.2"
 			}
 		},
 		"react-addons-create-fragment": {
@@ -9367,38 +9668,51 @@
 			}
 		},
 		"react-clientside-effect": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.1.tgz",
-			"integrity": "sha512-foSwZatJak6r+F4OqJ8a+MOWcBi3jwa7/RPdJIDZI1Ck0dn/FJZkkFu7YK+SiZxsCZIrotolxHSobcnBHgIjfw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz",
+			"integrity": "sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==",
 			"requires": {
 				"@babel/runtime": "^7.0.0"
 			}
 		},
-		"react-dev-utils": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-9.0.1.tgz",
-			"integrity": "sha512-pnaeMo/Pxel8aZpxk1WwxT3uXxM3tEwYvsjCYn5R7gNxjhN1auowdcLDzFB8kr7rafAj2rxmvfic/fbac5CzwQ==",
+		"react-color": {
+			"version": "2.17.3",
+			"resolved": "https://registry.npmjs.org/react-color/-/react-color-2.17.3.tgz",
+			"integrity": "sha512-1dtO8LqAVotPIChlmo6kLtFS1FP89ll8/OiA8EcFRDR+ntcK+0ukJgByuIQHRtzvigf26dV5HklnxDIvhON9VQ==",
 			"requires": {
-				"@babel/code-frame": "7.0.0",
-				"address": "1.0.3",
-				"browserslist": "4.5.4",
+				"@icons/material": "^0.2.4",
+				"lodash": "^4.17.11",
+				"material-colors": "^1.2.1",
+				"prop-types": "^15.5.10",
+				"reactcss": "^1.2.0",
+				"tinycolor2": "^1.4.1"
+			}
+		},
+		"react-dev-utils": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-9.0.3.tgz",
+			"integrity": "sha512-OyInhcwsvycQ3Zr2pQN+HV4gtRXrky5mJXIy4HnqrWa+mI624xfYfqGuC9dYbxp4Qq3YZzP8GSGQjv0AgNU15w==",
+			"requires": {
+				"@babel/code-frame": "7.5.5",
+				"address": "1.1.0",
+				"browserslist": "4.6.6",
 				"chalk": "2.4.2",
 				"cross-spawn": "6.0.5",
 				"detect-port-alt": "1.1.6",
 				"escape-string-regexp": "1.0.5",
 				"filesize": "3.6.1",
 				"find-up": "3.0.0",
-				"fork-ts-checker-webpack-plugin": "1.1.1",
+				"fork-ts-checker-webpack-plugin": "1.5.0",
 				"global-modules": "2.0.0",
 				"globby": "8.0.2",
-				"gzip-size": "5.0.0",
+				"gzip-size": "5.1.1",
 				"immer": "1.10.0",
-				"inquirer": "6.2.2",
-				"is-root": "2.0.0",
+				"inquirer": "6.5.0",
+				"is-root": "2.1.0",
 				"loader-utils": "1.2.3",
-				"opn": "5.4.0",
+				"open": "^6.3.0",
 				"pkg-up": "2.0.0",
-				"react-error-overlay": "^5.1.6",
+				"react-error-overlay": "^6.0.1",
 				"recursive-readdir": "2.2.2",
 				"shell-quote": "1.6.1",
 				"sockjs-client": "1.3.0",
@@ -9406,18 +9720,10 @@
 				"text-table": "0.2.0"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-					"requires": {
-						"@babel/highlight": "^7.0.0"
-					}
-				},
 				"address": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
-					"integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/address/-/address-1.1.0.tgz",
+					"integrity": "sha512-4diPfzWbLEIElVG4AnqP+00SULlPzNuyJFNnmMrLgyaxG6tZXJ1sn7mjBu4fHrJE+Yp/jgylOweJn2xsLMFggQ=="
 				},
 				"ansi-regex": {
 					"version": "3.0.0",
@@ -9425,13 +9731,13 @@
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"browserslist": {
-					"version": "4.5.4",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-					"integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+					"version": "4.6.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+					"integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
 					"requires": {
-						"caniuse-lite": "^1.0.30000955",
-						"electron-to-chromium": "^1.3.122",
-						"node-releases": "^1.1.13"
+						"caniuse-lite": "^1.0.30000984",
+						"electron-to-chromium": "^1.3.191",
+						"node-releases": "^1.1.25"
 					}
 				},
 				"cross-spawn": {
@@ -9464,9 +9770,9 @@
 					}
 				},
 				"inquirer": {
-					"version": "6.2.2",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
-					"integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+					"integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
 					"requires": {
 						"ansi-escapes": "^3.2.0",
 						"chalk": "^2.4.2",
@@ -9474,12 +9780,12 @@
 						"cli-width": "^2.0.0",
 						"external-editor": "^3.0.3",
 						"figures": "^2.0.0",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.12",
 						"mute-stream": "0.0.7",
 						"run-async": "^2.2.0",
 						"rxjs": "^6.4.0",
 						"string-width": "^2.1.0",
-						"strip-ansi": "^5.0.0",
+						"strip-ansi": "^5.1.0",
 						"through": "^2.3.6"
 					}
 				},
@@ -9494,9 +9800,9 @@
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				},
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				},
 				"string-width": {
 					"version": "2.1.1",
@@ -9548,6 +9854,11 @@
 				"recast": "^0.17.3"
 			},
 			"dependencies": {
+				"ast-types": {
+					"version": "0.12.4",
+					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.4.tgz",
+					"integrity": "sha512-ky/YVYCbtVAS8TdMIaTiPFHwEpRB5z1hctepJplTr3UW5q8TDrpIMCILyk8pmLxGtn2KCtC/lSn7zOsaI7nzDw=="
+				},
 				"recast": {
 					"version": "0.17.6",
 					"resolved": "https://registry.npmjs.org/recast/-/recast-0.17.6.tgz",
@@ -9567,38 +9878,38 @@
 			}
 		},
 		"react-dom": {
-			"version": "16.8.6",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
-			"integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
+			"version": "16.9.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
+			"integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
-				"scheduler": "^0.13.6"
+				"scheduler": "^0.15.0"
 			}
 		},
 		"react-draggable": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-3.3.0.tgz",
-			"integrity": "sha512-U7/jD0tAW4T0S7DCPK0kkKLyL0z61sC/eqU+NUfDjnq+JtBKaYKDHpsK2wazctiA4alEzCXUnzkREoxppOySVw==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-3.3.2.tgz",
+			"integrity": "sha512-oaz8a6enjbPtx5qb0oDWxtDNuybOylvto1QLydsXgKmwT7e3GXC2eMVDwEMIUYJIFqVG72XpOv673UuuAq6LhA==",
 			"requires": {
 				"classnames": "^2.2.5",
 				"prop-types": "^15.6.0"
 			}
 		},
 		"react-element-to-jsx-string": {
-			"version": "14.0.3",
-			"resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-14.0.3.tgz",
-			"integrity": "sha512-ziZAm7OwEfFtyhCmQiFNI87KFu+G9EP8qVW4XtDHdKNqqprYifLzqXkzHqC1vnVsPhyp2znoPm0bJHAf1mUBZA==",
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-14.1.0.tgz",
+			"integrity": "sha512-uvfAsY6bn2c8HMBkxwj+2MMXcvNIkKDl0aZg2Jhzp+c096hZaXUNivVCP2H4RBtmGSSJcfMqQA5oPk8YdqFOVw==",
 			"requires": {
-				"is-plain-object": "3.0.0",
-				"stringify-object": "3.3.0"
+				"@base2/pretty-print-object": "^1.0.0",
+				"is-plain-object": "3.0.0"
 			}
 		},
 		"react-error-overlay": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.6.tgz",
-			"integrity": "sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q=="
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.1.tgz",
+			"integrity": "sha512-V9yoTr6MeZXPPd4nV/05eCBvGH9cGzc52FN8fs0O0TVQ3HYYf1n7EgZVtHbldRq5xU9zEzoXIITjYNIfxDDdUw=="
 		},
 		"react-fast-compare": {
 			"version": "2.0.4",
@@ -9617,9 +9928,9 @@
 			}
 		},
 		"react-helmet-async": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.0.2.tgz",
-			"integrity": "sha512-qzzchrM/ibHuPS/60ief8jaibPunuRdeta4iBDQV+ri2SFKwOV+X2NlEpvevZOauhmHrH/I6dI4E90EPVfJBBg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.0.3.tgz",
+			"integrity": "sha512-hthnzAPasSX0ZU0adR1YW51xtMhwQuMwxtyjb/OeS2Gu2bzqFnCtt2h93nENE0+97NPeUS0+YHOriEMX8j/W0w==",
 			"requires": {
 				"@babel/runtime": "7.3.4",
 				"invariant": "2.2.4",
@@ -9651,10 +9962,28 @@
 				"prop-types": "^15.6.1"
 			}
 		},
+		"react-input-autosize": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.1.tgz",
+			"integrity": "sha512-3+K4CD13iE4lQQ2WlF8PuV5htfmTRLH6MDnfndHM6LuBRszuXnuyIfE7nhSKt8AzRBZ50bu0sAhkNMeS5pxQQA==",
+			"requires": {
+				"prop-types": "^15.5.8"
+			}
+		},
+		"react-inspector": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-3.0.2.tgz",
+			"integrity": "sha512-PSR8xDoGFN8R3LKmq1NT+hBBwhxjd9Qwz8yKY+5NXY/CHpxXHm01CVabxzI7zFwFav/M3JoC/Z0Ro2kSX6Ef2Q==",
+			"requires": {
+				"babel-runtime": "^6.26.0",
+				"is-dom": "^1.0.9",
+				"prop-types": "^15.6.1"
+			}
+		},
 		"react-is": {
-			"version": "16.8.6",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-			"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+			"version": "16.9.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
+			"integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
 		},
 		"react-lifecycles-compat": {
 			"version": "3.0.4",
@@ -9662,12 +9991,12 @@
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
 		},
 		"react-popper": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.3.tgz",
-			"integrity": "sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.4.tgz",
+			"integrity": "sha512-9AcQB29V+WrBKk6X7p0eojd1f25/oJajVdMZkywIoAV6Ag7hzE1Mhyeup2Q1QnvFRtGQFQvtqfhlEoDAPfKAVA==",
 			"requires": {
 				"@babel/runtime": "^7.1.2",
-				"create-react-context": "<=0.2.2",
+				"create-react-context": "^0.3.0",
 				"popper.js": "^1.14.4",
 				"prop-types": "^15.6.1",
 				"typed-styles": "^0.0.7",
@@ -9675,12 +10004,12 @@
 			},
 			"dependencies": {
 				"create-react-context": {
-					"version": "0.2.2",
-					"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.2.tgz",
-					"integrity": "sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==",
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
+					"integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
 					"requires": {
-						"fbjs": "^0.8.0",
-						"gud": "^1.0.0"
+						"gud": "^1.0.0",
+						"warning": "^4.0.3"
 					}
 				},
 				"warning": {
@@ -9702,16 +10031,32 @@
 				"react-popper": "^1.3.3"
 			}
 		},
-		"react-resize-detector": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-4.2.0.tgz",
-			"integrity": "sha512-AtOaNIxs0ydua7tEoglXR3902/EdlIj9PXDu1Zj0ug2VAUnkSQjguLGzaG/N6CXLOhJSccTsUCZxjLayQ1mE9Q==",
+		"react-select": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/react-select/-/react-select-3.0.4.tgz",
+			"integrity": "sha512-fbVISKa/lSUlLsltuatfUiKcWCNvdLXxFFyrzVQCBUsjxJZH/m7UMPdw/ywmRixAmwXAP++MdbNNZypOsiDEfA==",
 			"requires": {
-				"lodash": "^4.17.11",
-				"lodash-es": "^4.17.11",
-				"prop-types": "^15.7.2",
-				"raf-schd": "^4.0.0",
-				"resize-observer-polyfill": "^1.5.1"
+				"@babel/runtime": "^7.4.4",
+				"@emotion/cache": "^10.0.9",
+				"@emotion/core": "^10.0.9",
+				"@emotion/css": "^10.0.9",
+				"classnames": "^2.2.5",
+				"memoize-one": "^5.0.0",
+				"prop-types": "^15.6.0",
+				"raf": "^3.4.0",
+				"react-input-autosize": "^2.2.1",
+				"react-transition-group": "^2.2.1"
+			}
+		},
+		"react-sizeme": {
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-2.6.7.tgz",
+			"integrity": "sha512-xCjPoBP5jmeW58TxIkcviMZqabZis7tTvDFWf0/Wa5XCgVWQTIe74NQBes2N1Kmp64GRLkpm60BaP0kk+v8aCQ==",
+			"requires": {
+				"element-resize-detector": "^1.1.15",
+				"invariant": "^2.2.4",
+				"shallowequal": "^1.1.0",
+				"throttle-debounce": "^2.1.0"
 			}
 		},
 		"react-syntax-highlighter": {
@@ -9727,15 +10072,15 @@
 			}
 		},
 		"react-test-renderer": {
-			"version": "16.8.6",
-			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",
-			"integrity": "sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==",
+			"version": "16.9.0",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.9.0.tgz",
+			"integrity": "sha512-R62stB73qZyhrJo7wmCW9jgl/07ai+YzvouvCXIJLBkRlRqLx4j9RqcLEAfNfU3OxTGucqR2Whmn3/Aad6L3hQ==",
 			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
-				"react-is": "^16.8.6",
-				"scheduler": "^0.13.6"
+				"react-is": "^16.9.0",
+				"scheduler": "^0.15.0"
 			}
 		},
 		"react-textarea-autosize": {
@@ -9745,6 +10090,25 @@
 			"requires": {
 				"@babel/runtime": "^7.1.2",
 				"prop-types": "^15.6.0"
+			}
+		},
+		"react-transition-group": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+			"integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+			"requires": {
+				"dom-helpers": "^3.4.0",
+				"loose-envify": "^1.4.0",
+				"prop-types": "^15.6.2",
+				"react-lifecycles-compat": "^3.0.4"
+			}
+		},
+		"reactcss": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
+			"integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+			"requires": {
+				"lodash": "^4.0.1"
 			}
 		},
 		"read-pkg": {
@@ -9855,25 +10219,20 @@
 			}
 		},
 		"recast": {
-			"version": "0.14.7",
-			"resolved": "https://registry.npmjs.org/recast/-/recast-0.14.7.tgz",
-			"integrity": "sha512-/nwm9pkrcWagN40JeJhkPaRxiHXBRkXyRh/hgU088Z/v+qCy+zIHHY6bC6o7NaKAxPqtE6nD8zBH1LfU0/Wx6A==",
+			"version": "0.11.23",
+			"resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+			"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
 			"requires": {
-				"ast-types": "0.11.3",
-				"esprima": "~4.0.0",
+				"ast-types": "0.9.6",
+				"esprima": "~3.1.0",
 				"private": "~0.1.5",
-				"source-map": "~0.6.1"
+				"source-map": "~0.5.0"
 			},
 			"dependencies": {
-				"ast-types": {
-					"version": "0.11.3",
-					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.3.tgz",
-					"integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA=="
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
 				}
 			}
 		},
@@ -9883,26 +10242,6 @@
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"requires": {
 				"resolve": "^1.1.6"
-			}
-		},
-		"recompose": {
-			"version": "0.30.0",
-			"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-			"integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-			"requires": {
-				"@babel/runtime": "^7.0.0",
-				"change-emitter": "^0.1.2",
-				"fbjs": "^0.8.1",
-				"hoist-non-react-statics": "^2.3.1",
-				"react-lifecycles-compat": "^3.0.2",
-				"symbol-observable": "^1.0.4"
-			},
-			"dependencies": {
-				"hoist-non-react-statics": {
-					"version": "2.5.5",
-					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-					"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-				}
 			}
 		},
 		"recursive-readdir": {
@@ -9959,9 +10298,9 @@
 			}
 		},
 		"regexp-tree": {
-			"version": "0.1.11",
-			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.11.tgz",
-			"integrity": "sha512-7/l/DgapVVDzZobwMCCgMlqiqyLFJ0cduo/j+3BcDJIB+yJdsYCfKuI3l/04NV+H/rfNRdPIDbXNZHM9XvQatg=="
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.13.tgz",
+			"integrity": "sha512-hwdV/GQY5F8ReLZWO+W1SRoN5YfpOKY6852+tBFcma72DKBIcHjPRIlIvQN35bCOljuAfP2G2iB0FC/w236mUw=="
 		},
 		"regexp.prototype.flags": {
 			"version": "1.2.0",
@@ -9978,12 +10317,12 @@
 			"dev": true
 		},
 		"regexpu-core": {
-			"version": "4.5.4",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-			"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+			"integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
 			"requires": {
 				"regenerate": "^1.4.0",
-				"regenerate-unicode-properties": "^8.0.2",
+				"regenerate-unicode-properties": "^8.1.0",
 				"regjsgen": "^0.5.0",
 				"regjsparser": "^0.6.0",
 				"unicode-match-property-ecmascript": "^1.0.4",
@@ -10149,9 +10488,9 @@
 			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
 		},
 		"resolve": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-			"integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -10181,11 +10520,26 @@
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"rimraf": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 			"requires": {
 				"glob": "^7.1.3"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
 			}
 		},
 		"ripemd160": {
@@ -10224,9 +10578,9 @@
 			}
 		},
 		"rxjs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
-			"integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+			"integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -10264,9 +10618,9 @@
 			}
 		},
 		"scheduler": {
-			"version": "0.13.6",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-			"integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
+			"integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -10336,9 +10690,9 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
-			"integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA=="
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
+			"integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A=="
 		},
 		"serve-favicon": {
 			"version": "2.5.0",
@@ -10496,6 +10850,21 @@
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
 				"rechoir": "^0.6.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
 			}
 		},
 		"signal-exit": {
@@ -10504,9 +10873,9 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"simplebar": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.1.0.tgz",
-			"integrity": "sha512-kX+CsWbWLeufIsqJl8xg5J4WbYMyq5NONR/aTaehN8XLQxOthSgRT/uAXsqX9Yrw3iiGxD9PPwM1PmEJfWAdcg==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.2.1.tgz",
+			"integrity": "sha512-5BktrSuFwg2hA7ObLkfAGV2C1qKGZoyy9v1vVOQVddG89NU4BQ4TbkaJR23hgeEisnYVLGRH9f099YPBujuo7Q==",
 			"requires": {
 				"can-use-dom": "^0.1.0",
 				"core-js": "^3.0.1",
@@ -10517,33 +10886,33 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "3.1.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-					"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 				}
 			}
 		},
 		"simplebar-react": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-1.1.0.tgz",
-			"integrity": "sha512-0nbUpoB5Gq3z2dbhRjPxwTLlscgFjCw8vKQRmbXIr47JMc5BeHj/WbZdVAESuKAvua7ESh6mkxbzywMNgRdbCw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-1.2.1.tgz",
+			"integrity": "sha512-TOw1q5JhsXJCAYzfsdis5rwSZXemthNxTXKBo+E4brIS3FaMGE3AuA5YgFIu2xeTy/jRKekiQJwJCUx/RH7i7A==",
 			"requires": {
 				"prop-types": "^15.6.1",
-				"simplebar": "^4.1.0"
+				"simplebar": "^4.2.1"
 			}
 		},
 		"sinon": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
-			"integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.4.2.tgz",
+			"integrity": "sha512-pY5RY99DKelU3pjNxcWo6XqeB1S118GBcVIIdDi6V+h6hevn1izcg2xv1hTHW/sViRXU7sUOxt4wTUJ3gsW2CQ==",
 			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^1.4.0",
 				"@sinonjs/formatio": "^3.2.1",
-				"@sinonjs/samsam": "^3.3.1",
+				"@sinonjs/samsam": "^3.3.3",
 				"diff": "^3.5.0",
-				"lolex": "^4.0.1",
-				"nise": "^1.4.10",
+				"lolex": "^4.2.0",
+				"nise": "^1.5.2",
 				"supports-color": "^5.5.0"
 			}
 		},
@@ -10735,9 +11104,9 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.12",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-			"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+			"version": "0.5.13",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -10866,9 +11235,9 @@
 			"dev": true
 		},
 		"store2": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/store2/-/store2-2.8.0.tgz",
-			"integrity": "sha512-FBJpcOEZQLZBIGL4Yp7W5RgZ0ejaURmcfUjIpyOb64BpI8z/iJXw7zd/NTBeq304dVMxuWVDZEUUCGn7llaVrA=="
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/store2/-/store2-2.9.0.tgz",
+			"integrity": "sha512-JmK+95jLX2zAP75DVAJ1HAziQ6f+f495h4P9ez2qbmxazN6fE7doWlitqx9hj2YohH3kOi6RVksJe1UH0sJfPw=="
 		},
 		"stream-browserify": {
 			"version": "2.0.2",
@@ -10963,22 +11332,30 @@
 				"function-bind": "^1.1.1"
 			}
 		},
+		"string.prototype.trimleft": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+			"integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
+			}
+		},
+		"string.prototype.trimright": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+			"integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
+			}
+		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
 				"safe-buffer": "~5.1.0"
-			}
-		},
-		"stringify-object": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
-			"integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
-			"requires": {
-				"get-own-enumerable-property-symbols": "^3.0.0",
-				"is-obj": "^1.0.1",
-				"is-regexp": "^1.0.0"
 			}
 		},
 		"strip-ansi": {
@@ -11070,11 +11447,6 @@
 				}
 			}
 		},
-		"symbol-observable": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-		},
 		"symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -11090,9 +11462,9 @@
 			}
 		},
 		"table": {
-			"version": "5.4.4",
-			"resolved": "https://registry.npmjs.org/table/-/table-5.4.4.tgz",
-			"integrity": "sha512-IIfEAUx5QlODLblLrGTTLJA7Tk0iLSGBvgY8essPRVNGHAzThujww1YqHLs6h3HfTg55h++RzLHH5Xw/rfv+mg==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+			"integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.10.2",
@@ -11163,9 +11535,9 @@
 			}
 		},
 		"terser": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.1.2.tgz",
-			"integrity": "sha512-jvNoEQSPXJdssFwqPSgWjsOrb+ELoE+ILpHPKXC83tIxOlh2U75F1KuB2luLD/3a6/7K3Vw5pDn+hvu0C4AzSw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.3.1.tgz",
+			"integrity": "sha512-pnzH6dnFEsR2aa2SJaKb1uSCl3QmIsJ8dEkj0Fky+2AwMMcC9doMqLOQIH6wVTEKaVfKVvLSk5qxPBEZT9mywg==",
 			"requires": {
 				"commander": "^2.20.0",
 				"source-map": "~0.6.1",
@@ -11180,19 +11552,18 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz",
-			"integrity": "sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
+			"integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
 			"requires": {
-				"cacache": "^11.3.2",
-				"find-cache-dir": "^2.0.0",
+				"cacache": "^12.0.2",
+				"find-cache-dir": "^2.1.0",
 				"is-wsl": "^1.1.0",
-				"loader-utils": "^1.2.3",
 				"schema-utils": "^1.0.0",
 				"serialize-javascript": "^1.7.0",
 				"source-map": "^0.6.1",
-				"terser": "^4.0.0",
-				"webpack-sources": "^1.3.0",
+				"terser": "^4.1.2",
+				"webpack-sources": "^1.4.0",
 				"worker-farm": "^1.7.0"
 			},
 			"dependencies": {
@@ -11218,6 +11589,11 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
 		},
+		"throttle-debounce": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.1.0.tgz",
+			"integrity": "sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg=="
+		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -11233,9 +11609,9 @@
 			}
 		},
 		"timers-browserify": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+			"integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
 			"requires": {
 				"setimmediate": "^1.0.4"
 			}
@@ -11245,6 +11621,11 @@
 			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
 			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
 			"optional": true
+		},
+		"tinycolor2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
+			"integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
 		},
 		"tmp": {
 			"version": "0.0.33",
@@ -11338,9 +11719,9 @@
 			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
 		},
 		"ts-pnp": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.2.tgz",
-			"integrity": "sha512-f5Knjh7XCyRIzoC/z1Su1yLLRrPrFCgtUAh/9fCSP6NKbATwpOL1+idQVXQokK9GRFURn/jYPGPfegIctwunoA=="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.4.tgz",
+			"integrity": "sha512-1J/vefLC+BWSo+qe8OnJQfWTYRS6ingxjwqmHMqaMxXMj7kFtKLgAaYW3JeX3mktjgUL+etlU8/B4VUAUI9QGw=="
 		},
 		"tslib": {
 			"version": "1.10.0",
@@ -11426,6 +11807,11 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
+		},
+		"unfetch": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.1.0.tgz",
+			"integrity": "sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg=="
 		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
@@ -11535,9 +11921,9 @@
 			}
 		},
 		"upath": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
-			"integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
 		},
 		"upper-case": {
 			"version": "1.1.3",
@@ -11574,19 +11960,28 @@
 			}
 		},
 		"url-loader": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.1.2.tgz",
-			"integrity": "sha512-dXHkKmw8FhPqu8asTc1puBfe3TehOCo2+RmOOev5suNCIYBcT626kxiWg1NBVkwc4rO8BGa7gP70W7VXuqHrjg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-2.1.0.tgz",
+			"integrity": "sha512-kVrp/8VfEm5fUt+fl2E0FQyrpmOYgMEkBsv8+UDP1wFhszECq5JyGF33I7cajlVY90zRZ6MyfgKXngLvHYZX8A==",
 			"requires": {
-				"loader-utils": "^1.1.0",
-				"mime": "^2.0.3",
-				"schema-utils": "^1.0.0"
+				"loader-utils": "^1.2.3",
+				"mime": "^2.4.4",
+				"schema-utils": "^2.0.0"
 			},
 			"dependencies": {
 				"mime": {
 					"version": "2.4.4",
 					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
 					"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+				},
+				"schema-utils": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.2.0.tgz",
+					"integrity": "sha512-5EwsCNhfFTZvUreQhx/4vVQpJ/lnCAkgoIHLhSpp4ZirE+4hzFvdJi0FMub6hxbFVBJYSpeVVmon+2e7uEGRrA==",
+					"requires": {
+						"ajv": "^6.10.2",
+						"ajv-keywords": "^3.4.1"
+					}
 				}
 			}
 		},
@@ -11644,14 +12039,14 @@
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
 		},
 		"v8-compile-cache": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
-			"integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -11730,42 +12125,50 @@
 			"dev": true
 		},
 		"webpack": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.38.0.tgz",
-			"integrity": "sha512-lbuFsVOq8PZY+1Ytz/mYOvYOo+d4IJ31hHk/7iyoeWtwN33V+5HYotSH+UIb9tq914ey0Hot7z6HugD+je3sWw==",
+			"version": "4.40.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.40.2.tgz",
+			"integrity": "sha512-5nIvteTDCUws2DVvP9Qe+JPla7kWPPIDFZv55To7IycHWZ+Z5qBdaBYPyuXWdhggTufZkQwfIK+5rKQTVovm2A==",
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
 				"@webassemblyjs/helper-module-context": "1.8.5",
 				"@webassemblyjs/wasm-edit": "1.8.5",
 				"@webassemblyjs/wasm-parser": "1.8.5",
-				"acorn": "^6.2.0",
-				"ajv": "^6.1.0",
-				"ajv-keywords": "^3.1.0",
-				"chrome-trace-event": "^1.0.0",
+				"acorn": "^6.2.1",
+				"ajv": "^6.10.2",
+				"ajv-keywords": "^3.4.1",
+				"chrome-trace-event": "^1.0.2",
 				"enhanced-resolve": "^4.1.0",
-				"eslint-scope": "^4.0.0",
+				"eslint-scope": "^4.0.3",
 				"json-parse-better-errors": "^1.0.2",
-				"loader-runner": "^2.3.0",
-				"loader-utils": "^1.1.0",
-				"memory-fs": "~0.4.1",
-				"micromatch": "^3.1.8",
-				"mkdirp": "~0.5.0",
-				"neo-async": "^2.5.0",
-				"node-libs-browser": "^2.0.0",
+				"loader-runner": "^2.4.0",
+				"loader-utils": "^1.2.3",
+				"memory-fs": "^0.4.1",
+				"micromatch": "^3.1.10",
+				"mkdirp": "^0.5.1",
+				"neo-async": "^2.6.1",
+				"node-libs-browser": "^2.2.1",
 				"schema-utils": "^1.0.0",
-				"tapable": "^1.1.0",
-				"terser-webpack-plugin": "^1.1.0",
-				"watchpack": "^1.5.0",
-				"webpack-sources": "^1.3.0"
+				"tapable": "^1.1.3",
+				"terser-webpack-plugin": "^1.4.1",
+				"watchpack": "^1.6.0",
+				"webpack-sources": "^1.4.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+					"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA=="
+				}
 			}
 		},
 		"webpack-dev-middleware": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.0.tgz",
-			"integrity": "sha512-qvDesR1QZRIAZHOE3iQ4CXLZZSQ1lAUsSpnQmlB1PBfoN/xdRjmge3Dok0W4IdaVLJOGJy3sGI4sZHwjRU0PCA==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.1.tgz",
+			"integrity": "sha512-5MWu9SH1z3hY7oHOV6Kbkz5x7hXbxK56mGHNqHTe6d+ewxOwKUxoUJBs7QIaJb33lPjl9bJZ3X0vCoooUzC36A==",
 			"requires": {
 				"memory-fs": "^0.4.1",
-				"mime": "^2.4.2",
+				"mime": "^2.4.4",
+				"mkdirp": "^0.5.1",
 				"range-parser": "^1.2.1",
 				"webpack-log": "^2.0.0"
 			},
@@ -11798,9 +12201,9 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
-			"integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+			"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
 			"requires": {
 				"source-list-map": "^2.0.0",
 				"source-map": "~0.6.1"
@@ -11965,9 +12368,9 @@
 			}
 		},
 		"ws": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.1.1.tgz",
-			"integrity": "sha512-o41D/WmDeca0BqYhsr3nJzQyg9NF5X8l/UdnFNux9cS3lwB+swm8qGWX5rn+aD6xfBU3rGmtHij7g7x6LxFU3A==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
+			"integrity": "sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==",
 			"dev": true,
 			"requires": {
 				"async-limiter": "^1.0.0"
@@ -11980,9 +12383,9 @@
 			"dev": true
 		},
 		"xmlchars": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.1.1.tgz",
-			"integrity": "sha512-7hew1RPJ1iIuje/Y01bGD/mXokXxegAgVS+e+E0wSi2ILHQkYAH1+JXARwTjZSM4Z4Z+c73aKspEcqj+zPPL/w==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
 		},
 		"xtend": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-storybook-addon-chapters",
-	"version": "3.1.5",
+	"version": "3.1.6",
 	"description": "React Storybook Chapters addon allows showcasing of multiple components within a story by breaking it down into smaller categories (chapters) and subcategories (sections) for more organizational goodness.",
 	"repository": {
 		"type": "git",
@@ -53,9 +53,9 @@
 		"@babel/plugin-proposal-class-properties": "^7.5.5",
 		"@babel/polyfill": "^7.4.4",
 		"@emotion/styled": "^10.0.14",
-		"@storybook/addon-info": "^5.1.9",
-		"@storybook/components": "^5.1.9",
-		"@storybook/react": "^5.1.9",
+		"@storybook/addon-info": "^5.2.1",
+		"@storybook/components": "^5.2.1",
+		"@storybook/react": "^5.2.1",
 		"marksy": "2.0.1",
 		"react": "^16.8.6"
 	},

--- a/src/components/Node.jsx
+++ b/src/components/Node.jsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import Props from '@storybook/addon-info/dist/components/Props';
+import PropTypes from 'prop-types';
+
+const stylesheet = {
+  containerStyle: {},
+  tagStyle: {
+    color: '#444',
+  },
+};
+
+function getData(element) {
+  const data = {
+    name: null,
+    text: null,
+    children: null,
+  };
+
+  if (element === null) {
+    return data;
+  }
+
+  if (typeof element === 'string') {
+    data.text = element;
+    return data;
+  }
+
+  if (typeof element === 'number') {
+    data.text = String.toString(element);
+    return data;
+  }
+
+  data.children = element.props.children;
+  const { type } = element;
+
+  if (typeof type === 'string') {
+    data.name = type;
+  } else {
+    data.name = type.displayName || type.name || 'Unknown';
+  }
+
+  return data;
+}
+
+export default function Node(props) {
+  const {
+    node,
+    depth,
+    maxPropsIntoLine,
+    maxPropObjectKeys,
+    maxPropArrayLength,
+    maxPropStringLength,
+  } = props;
+  const { tagStyle, containerStyle } = stylesheet;
+
+  const leftPad = {
+    paddingLeft: 3 + (depth + 1) * 15,
+    paddingRight: 3,
+  };
+
+  // Keep a copy so that further mutations to containerStyle don't impact us:
+  const containerStyleCopy = Object.assign({}, containerStyle, leftPad);
+
+  const { name, text, children } = getData(node);
+
+  // Just text
+  if (!name) {
+    return (
+      <div style={containerStyleCopy}>
+        <span style={tagStyle}>{text}</span>
+      </div>
+    );
+  }
+
+  // Single-line tag
+  if (!children) {
+    return (
+      <div style={containerStyleCopy}>
+        <span style={tagStyle}>
+          &lt;
+          {name}
+        </span>
+        <Props
+          node={node}
+          singleLine
+          maxPropsIntoLine={maxPropsIntoLine}
+          maxPropObjectKeys={maxPropObjectKeys}
+          maxPropArrayLength={maxPropArrayLength}
+          maxPropStringLength={maxPropStringLength}
+        />
+        <span style={tagStyle}>/&gt;</span>
+      </div>
+    );
+  }
+
+  // tag with children
+  return (
+    <div>
+      <div style={containerStyleCopy}>
+        <span style={tagStyle}>
+          &lt;
+          {name}
+        </span>
+        <Props
+          node={node}
+          maxPropsIntoLine={maxPropsIntoLine}
+          maxPropObjectKeys={maxPropObjectKeys}
+          maxPropArrayLength={maxPropArrayLength}
+          maxPropStringLength={maxPropStringLength}
+        />
+        <span style={tagStyle}>&gt;</span>
+      </div>
+      {React.Children.map(children, childElement => (
+        <Node
+          node={childElement}
+          depth={depth + 1}
+          maxPropsIntoLine={maxPropsIntoLine}
+          maxPropObjectKeys={maxPropObjectKeys}
+          maxPropArrayLength={maxPropArrayLength}
+          maxPropStringLength={maxPropStringLength}
+        />
+      ))}
+      <div style={containerStyleCopy}>
+        <span style={tagStyle}>
+          &lt;/
+          {name}
+          &gt;
+        </span>
+      </div>
+    </div>
+  );
+}
+
+Node.defaultProps = {
+  node: null,
+  depth: 0,
+};
+
+Node.propTypes = {
+  node: PropTypes.node,
+  depth: PropTypes.number,
+  maxPropsIntoLine: PropTypes.number.isRequired,
+  maxPropObjectKeys: PropTypes.number.isRequired,
+  maxPropArrayLength: PropTypes.number.isRequired,
+  maxPropStringLength: PropTypes.number.isRequired,
+};

--- a/src/components/Section.jsx
+++ b/src/components/Section.jsx
@@ -1,359 +1,354 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Node from '@storybook/addon-info/dist/components/Node';
+import Node from './Node';
 import PropTable from './PropTable';
 import renderInfoContent from '../utils/info-content';
 import theme from '../theme';
 
 const propTypes = {
-  title: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  info: PropTypes.string,
-  showSource: PropTypes.bool,
-  showPropTables: PropTypes.bool,
-  propTables: PropTypes.arrayOf(PropTypes.func),
-  children: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.array,
-  ]).isRequired,
-  allowSourceToggling: PropTypes.bool,
-  allowPropTablesToggling: PropTypes.bool,
-  addonInfo: PropTypes.object.isRequired,
-  useTheme: PropTypes.bool,
+	title: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+	subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+	info: PropTypes.string,
+	showSource: PropTypes.bool,
+	showPropTables: PropTypes.bool,
+	propTables: PropTypes.arrayOf(PropTypes.func),
+	children: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
+	allowSourceToggling: PropTypes.bool,
+	allowPropTablesToggling: PropTypes.bool,
+	addonInfo: PropTypes.object.isRequired,
+	useTheme: PropTypes.bool
 };
 
 const defaultProps = {
-  title: '',
-  subtitle: '',
-  info: '',
-  showSource: true,
-  allowSourceToggling: true,
-  showPropTables: false,
-  allowPropTablesToggling: true,
-  useTheme: false,
+	title: '',
+	subtitle: '',
+	info: '',
+	showSource: true,
+	allowSourceToggling: true,
+	showPropTables: false,
+	allowPropTablesToggling: true,
+	useTheme: false
 };
 
 export const sectionButtonStyles = {
-  backgroundColor: 'transparent',
-  border: `1px solid ${theme.gray}`,
-  borderRadius: 3,
-  color: theme.grayDark,
-  cursor: 'pointer',
-  float: 'right',
-  marginLeft: 5,
-  padding: '5px 10px',
-
+	backgroundColor: 'transparent',
+	border: `1px solid ${theme.gray}`,
+	borderRadius: 3,
+	color: theme.grayDark,
+	cursor: 'pointer',
+	float: 'right',
+	marginLeft: 5,
+	padding: '5px 10px'
 };
 
 export const sectionStyles = {
-  container: {
-    marginBottom: 100,
-  },
-  header: {
-    marginBottom: 60,
-  },
-  title: {
-    color: theme.grayDarkest,
-    fontSize: 18,
-    marginBottom: 10,
-  },
-  subtitle: {
-    color: theme.grayDark,
-    fontSize: 14,
-    marginBottom: 20,
-    marginTop: 0,
-  },
-  buttonContainer: {
-    height: 15,
-  },
-  button: sectionButtonStyles,
-  'button-active': {
-    ...sectionButtonStyles,
-    backgroundColor: theme.grayLight,
-    borderColor: theme.grayLight,
-    color: theme.grayDark,
-  },
-  info: theme.infoStyle,
-  componentContainer: {
-    marginBottom: 60,
-  },
-  subsection: {
-    marginBottom: 60,
-  },
-  subsectionTitle: {
-    color: theme.grayDark,
-    fontSize: 12,
-    letterSpacing: 2,
-    textTransform: 'uppercase',
-  },
-  pre: {
-    fontSize: '.88em',
-    fontFamily: 'Menlo, Monaco, "Courier New", monospace',
-    backgroundColor: 'rgb(250, 250, 250)',
-    padding: '0.5rem',
-    lineHeight: '1.5',
-    overflowX: 'scroll',
-  },
+	container: {
+		marginBottom: 100
+	},
+	header: {
+		marginBottom: 60
+	},
+	title: {
+		color: theme.grayDarkest,
+		fontSize: 18,
+		marginBottom: 10
+	},
+	subtitle: {
+		color: theme.grayDark,
+		fontSize: 14,
+		marginBottom: 20,
+		marginTop: 0
+	},
+	buttonContainer: {
+		height: 15
+	},
+	button: sectionButtonStyles,
+	'button-active': {
+		...sectionButtonStyles,
+		backgroundColor: theme.grayLight,
+		borderColor: theme.grayLight,
+		color: theme.grayDark
+	},
+	info: theme.infoStyle,
+	componentContainer: {
+		marginBottom: 60
+	},
+	subsection: {
+		marginBottom: 60
+	},
+	subsectionTitle: {
+		color: theme.grayDark,
+		fontSize: 12,
+		letterSpacing: 2,
+		textTransform: 'uppercase'
+	},
+	pre: {
+		fontSize: '.88em',
+		fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+		backgroundColor: 'rgb(250, 250, 250)',
+		padding: '0.5rem',
+		lineHeight: '1.5',
+		overflowX: 'scroll'
+	}
 };
 
 export class SectionDecorator {
-  static main(header, component, additional, useTheme) {
-    return (
-      <div style={useTheme ? sectionStyles.container : {}} className="section-container">
-        {header}
-        {component}
-        {additional}
-      </div>
-    );
-  }
+	static main(header, component, additional, useTheme) {
+		return (
+			<div style={useTheme ? sectionStyles.container : {}} className="section-container">
+				{header}
+				{component}
+				{additional}
+			</div>
+		);
+	}
 
-  static header(header, useTheme) {
-    return (
-      <div style={useTheme ? sectionStyles.header : {}} className="section-header">
-        {header}
-      </div>
-    );
-  }
+	static header(header, useTheme) {
+		return (
+			<div style={useTheme ? sectionStyles.header : {}} className="section-header">
+				{header}
+			</div>
+		);
+	}
 
-  static title(title, useTheme) {
-    return (
-      <h3 style={useTheme ? sectionStyles.title : {}} className="section-title">{title}</h3>
-    );
-  }
+	static title(title, useTheme) {
+		return (
+			<h3 style={useTheme ? sectionStyles.title : {}} className="section-title">
+				{title}
+			</h3>
+		);
+	}
 
-  static subtitle(subtitle, useTheme) {
-    return (
-      <p style={useTheme ? sectionStyles.subtitle : {}} className="section-subtitle">{subtitle}</p>
-    );
-  }
+	static subtitle(subtitle, useTheme) {
+		return (
+			<p style={useTheme ? sectionStyles.subtitle : {}} className="section-subtitle">
+				{subtitle}
+			</p>
+		);
+	}
 
-  static component(component, useTheme, decorator) {
-    const decoratedComponent = decorator ? decorator(() => component) : component;
+	static component(component, useTheme, decorator) {
+		const decoratedComponent = decorator ? decorator(() => component) : component;
 
-    return (
-      <div
-        style={useTheme ? sectionStyles.componentContainer : {}}
-        className="section-component-container"
-      >
-        {decoratedComponent}
-      </div>
-    );
-  }
+		return (
+			<div style={useTheme ? sectionStyles.componentContainer : {}} className="section-component-container">
+				{decoratedComponent}
+			</div>
+		);
+	}
 
-  static additional(additional, useTheme) {
-    return (
-      <div style={useTheme ? sectionStyles.additional : {}} className="section-additional">
-        {additional}
-      </div>
-    );
-  }
+	static additional(additional, useTheme) {
+		return (
+			<div style={useTheme ? sectionStyles.additional : {}} className="section-additional">
+				{additional}
+			</div>
+		);
+	}
 
-  static sourceCode(sourceCode, useTheme) {
-    return (
-      <div style={useTheme ? sectionStyles.subsection : {}} className="section-subsection">
-        <h4 style={useTheme ? sectionStyles.subsection.title : {}} className="section-subsection-title">Source</h4>
-        <pre style={useTheme ? sectionStyles.pre : {}} className="section-pre">
-          {sourceCode}
-        </pre>
-      </div>
-    );
-  }
+	static sourceCode(sourceCode, useTheme) {
+		return (
+			<div style={useTheme ? sectionStyles.subsection : {}} className="section-subsection">
+				<h4 style={useTheme ? sectionStyles.subsection.title : {}} className="section-subsection-title">
+					Source
+				</h4>
+				<pre style={useTheme ? sectionStyles.pre : {}} className="section-pre">
+					{sourceCode}
+				</pre>
+			</div>
+		);
+	}
 
-  static propTables(propTables, useTheme) {
-    return (
-      <div style={useTheme ? sectionStyles.subsection : {}} className="section-subsection">
-        <h4 style={useTheme ? sectionStyles.subsection.title : {}} className="section-subsection-title">PropTypes</h4>
-        {propTables}
-      </div>
-    );
-  }
+	static propTables(propTables, useTheme) {
+		return (
+			<div style={useTheme ? sectionStyles.subsection : {}} className="section-subsection">
+				<h4 style={useTheme ? sectionStyles.subsection.title : {}} className="section-subsection-title">
+					PropTypes
+				</h4>
+				{propTables}
+			</div>
+		);
+	}
 
-  static buttons(buttons, useTheme) {
-    return (
-      <div style={useTheme ? sectionStyles.buttonContainer : {}} className="section-button-container">{buttons}</div>
-    );
-  }
+	static buttons(buttons, useTheme) {
+		return (
+			<div style={useTheme ? sectionStyles.buttonContainer : {}} className="section-button-container">
+				{buttons}
+			</div>
+		);
+	}
 
-  static info(infoContent, useTheme) {
-    return (
-      <div style={useTheme ? sectionStyles.subsection : {}} className="section-subsection">
-        <div style={useTheme ? sectionStyles.info : {}} className="section-info">
-          {infoContent}
-        </div>
-      </div>
-    );
-  }
+	static info(infoContent, useTheme) {
+		return (
+			<div style={useTheme ? sectionStyles.subsection : {}} className="section-subsection">
+				<div style={useTheme ? sectionStyles.info : {}} className="section-info">
+					{infoContent}
+				</div>
+			</div>
+		);
+	}
 }
 
-
 export default class Section extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isSourceShown: props.showSource,
-      isPropsTableShown: props.showPropTables,
-    };
-  }
+	constructor(props) {
+		super(props);
+		this.state = {
+			isSourceShown: props.showSource,
+			isPropsTableShown: props.showPropTables
+		};
+	}
 
-  renderSourceCode(useTheme) {
-    const { addonInfo, children } = this.props;
+	renderSourceCode(useTheme) {
+		const { addonInfo, children } = this.props;
 
-    const sourceCode = React.Children.map(children, (root, idx) => (
-      <Node key={idx} depth={0} node={root} {...addonInfo} {...this.props} />
-    ));
+		const sourceCode = React.Children.map(children, (root, idx) => (
+			<Node key={idx} depth={0} node={root} {...addonInfo} {...this.props} />
+		));
 
-    return SectionDecorator.sourceCode(sourceCode, useTheme);
-  }
+		return SectionDecorator.sourceCode(sourceCode, useTheme);
+	}
 
-  renderPropTables(useTheme) {
-    const { children, propTables } = this.props;
-    const components = new Map();
+	renderPropTables(useTheme) {
+		const { children, propTables } = this.props;
+		const components = new Map();
 
-    if (!children) {
-      return null;
-    }
+		if (!children) {
+			return null;
+		}
 
-    if (propTables) {
-      propTables.forEach(function (component) {
-        components.set(component, true);
-      });
-    }
+		if (propTables) {
+			propTables.forEach(function(component) {
+				components.set(component, true);
+			});
+		}
 
-    // Depth-first traverse and collect components.
-    function extract(traverseChildren) {
-      if (!traverseChildren) {
-        return;
-      }
-      if (Array.isArray(traverseChildren)) {
-        traverseChildren.forEach(extract);
-        return;
-      }
-      if (traverseChildren.props && traverseChildren.props.children) {
-        extract(traverseChildren.props.children);
-      }
-      if (typeof traverseChildren === 'string' || typeof traverseChildren.type === 'string') {
-        return;
-      }
-      if (traverseChildren.type && !components.has(traverseChildren.type)) {
-        components.set(traverseChildren.type, true);
-      }
-    }
+		// Depth-first traverse and collect components.
+		function extract(traverseChildren) {
+			if (!traverseChildren) {
+				return;
+			}
+			if (Array.isArray(traverseChildren)) {
+				traverseChildren.forEach(extract);
+				return;
+			}
+			if (traverseChildren.props && traverseChildren.props.children) {
+				extract(traverseChildren.props.children);
+			}
+			if (typeof traverseChildren === 'string' || typeof traverseChildren.type === 'string') {
+				return;
+			}
+			if (traverseChildren.type && !components.has(traverseChildren.type)) {
+				components.set(traverseChildren.type, true);
+			}
+		}
 
-    // Extract components from children.
-    extract(children);
+		// Extract components from children.
+		extract(children);
 
-    const componentsList = Array.from(components.keys());
-    componentsList.sort(function (a, b) {
-      return (a.displayName || a.name) > (b.displayName || b.name);
-    });
+		const componentsList = Array.from(components.keys());
+		componentsList.sort(function(a, b) {
+			return (a.displayName || a.name) > (b.displayName || b.name);
+		});
 
-    const newPropTables = componentsList.map(function (component, i) {
-      return (
-        <div key={i}>
-          <h5>
-&lt;
-            {component.displayName || component.name}
-&gt; Component
-          </h5>
-          <PropTable component={component} useTheme={useTheme} />
-        </div>
-      );
-    });
+		const newPropTables = componentsList.map(function(component, i) {
+			return (
+				<div key={i}>
+					<h5>
+						&lt;
+						{component.displayName || component.name}
+						&gt; Component
+					</h5>
+					<PropTable component={component} useTheme={useTheme} />
+				</div>
+			);
+		});
 
-    if (!newPropTables || newPropTables.length === 0) {
-      return null;
-    }
+		if (!newPropTables || newPropTables.length === 0) {
+			return null;
+		}
 
-    return SectionDecorator.propTables(newPropTables, useTheme);
-  }
+		return SectionDecorator.propTables(newPropTables, useTheme);
+	}
 
-  render() {
-    const {
-      title, subtitle, children, info, allowPropTablesToggling, allowSourceToggling, useTheme, decorator,
-    } = this.props;
-    const showButtonsRow = allowPropTablesToggling || allowSourceToggling;
+	render() {
+		const {
+			title,
+			subtitle,
+			children,
+			info,
+			allowPropTablesToggling,
+			allowSourceToggling,
+			useTheme,
+			decorator
+		} = this.props;
+		const showButtonsRow = allowPropTablesToggling || allowSourceToggling;
 
-    const { isPropsTableShown, isSourceShown } = this.state;
+		const { isPropsTableShown, isSourceShown } = this.state;
 
-    const header = (
-      <div>
-        {title && SectionDecorator.title(title, useTheme)}
-        {subtitle && SectionDecorator.subtitle(subtitle, useTheme)}
-      </div>
-    );
+		const header = (
+			<div>
+				{title && SectionDecorator.title(title, useTheme)}
+				{subtitle && SectionDecorator.subtitle(subtitle, useTheme)}
+			</div>
+		);
 
-    const buttons = [
-      allowPropTablesToggling
-      && (
-      <button
-        type="button"
-        key="allowPropTablesToggling"
-        onClick={() => {
-          this.setState({
-            isPropsTableShown: !this.state.isPropsTableShown,
-          });
-        }}
-        style={
-            useTheme
-              ? isPropsTableShown
-                ? sectionStyles['button-active']
-                : sectionStyles.button
-              : isPropsTableShown
-                ? sectionStyles['button-active']
-                : sectionStyles.button
-            }
-        className={isPropsTableShown ? 'button-active' : 'button'}
-      >
-        {isPropsTableShown ? 'Hide' : 'Show'}
-        {' '}
-Props Table
-      </button>
-      ),
+		const buttons = [
+			allowPropTablesToggling && (
+				<button
+					type="button"
+					key="allowPropTablesToggling"
+					onClick={() => {
+						this.setState({
+							isPropsTableShown: !this.state.isPropsTableShown
+						});
+					}}
+					style={
+						useTheme
+							? isPropsTableShown ? sectionStyles['button-active'] : sectionStyles.button
+							: isPropsTableShown ? sectionStyles['button-active'] : sectionStyles.button
+					}
+					className={isPropsTableShown ? 'button-active' : 'button'}
+				>
+					{isPropsTableShown ? 'Hide' : 'Show'} Props Table
+				</button>
+			),
 
-      allowSourceToggling
-      && (
-      <button
-        type="button"
-        key="allowSourceToggling"
-        onClick={() => {
-          this.setState({
-            isSourceShown: !isSourceShown,
-          });
-        }}
-        style={
-          useTheme
-            ? isSourceShown
-              ? sectionStyles['button-active']
-              : sectionStyles.button
-            : isSourceShown
-              ? sectionStyles['button-active']
-              : sectionStyles.button
-            }
-        className={isSourceShown ? 'button-active' : 'button'}
-      >
-        {isSourceShown ? 'Hide' : 'Show'}
-        {' '}
-Source
-      </button>
-      ),
-    ];
+			allowSourceToggling && (
+				<button
+					type="button"
+					key="allowSourceToggling"
+					onClick={() => {
+						this.setState({
+							isSourceShown: !isSourceShown
+						});
+					}}
+					style={
+						useTheme
+							? isSourceShown ? sectionStyles['button-active'] : sectionStyles.button
+							: isSourceShown ? sectionStyles['button-active'] : sectionStyles.button
+					}
+					className={isSourceShown ? 'button-active' : 'button'}
+				>
+					{isSourceShown ? 'Hide' : 'Show'} Source
+				</button>
+			)
+		];
 
-    const additional = (
-      <div>
-        {info && SectionDecorator.info(renderInfoContent(info), useTheme)}
-        {showButtonsRow && SectionDecorator.buttons(buttons, useTheme)}
-        {isSourceShown && this.renderSourceCode(useTheme)}
-        {isPropsTableShown && this.renderPropTables(useTheme)}
-      </div>
-    );
+		const additional = (
+			<div>
+				{info && SectionDecorator.info(renderInfoContent(info), useTheme)}
+				{showButtonsRow && SectionDecorator.buttons(buttons, useTheme)}
+				{isSourceShown && this.renderSourceCode(useTheme)}
+				{isPropsTableShown && this.renderPropTables(useTheme)}
+			</div>
+		);
 
-    return SectionDecorator.main(
-      SectionDecorator.header(header),
-      SectionDecorator.component(children, useTheme, decorator),
-      SectionDecorator.additional(additional),
-      useTheme,
-    );
-  }
+		return SectionDecorator.main(
+			SectionDecorator.header(header),
+			SectionDecorator.component(children, useTheme, decorator),
+			SectionDecorator.additional(additional),
+			useTheme
+		);
+	}
 }
 
 Section.displayName = 'Section';


### PR DESCRIPTION
Node.js was deprecated from the addon-info dependency.  I reached back in time for the file and added it to the component directory of this repo.  It fixes up the upgrade issue and works with most recent versions of @storybook, @storybook/components and @storybook/addon-info which were also throwing critical vuln notices